### PR TITLE
Add support for closing subscriptions

### DIFF
--- a/src/protocol/model.rs
+++ b/src/protocol/model.rs
@@ -313,10 +313,19 @@ pub mod payment {
         Rejected {
             reason: Option<String>,
         },
+        /* Use RecurringPaymentStatusSenderConversation
         Cancelled {
             subscription_id: String,
             reason: Option<String>,
         },
+        */
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+    pub struct CloseRecurringPaymentContent {
+        pub subscription_id: String,
+        pub reason: Option<String>,
     }
 }
 


### PR DESCRIPTION
**Title:** Add support for closing subscriptions

**Description:**

This PR introduces the ability to close an active subscription. This functionality is required to allow services and users to explicitly terminate a subscription when needed.

**To Do:**

* [ ] Add support for subscription closure in the service
* [ ] Add the corresponding endpoint to the `rest` module
* [ ] Implement the feature in the TypeScript client