### PR TITLE
Make the relay reconnection parallel and not sequential

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -413,6 +413,27 @@ impl PortalApp {
         Ok(Arc::new(Self { router, runtime }))
     }
 
+    /// Reconnect to all relays
+    ///
+    /// This method disconnects all relays and then connects them again.
+    pub async fn reconnect(&self) -> Result<(), AppError> {
+        let router = self.router.channel();
+
+        // 1. Disconnect all relays (sets them to Terminated)
+        router.disconnect().await;
+
+        // 2. Reset all relay connection stats
+        // let relays = router.relays().await;
+        // for relay in relays.values() {
+        //     relay.stats().reset_attempts();
+        // }
+
+        // 3. Connect all relays (spawns fresh tasks)
+        router.connect().await;
+
+        Ok(())
+    }
+
     pub async fn shutdown(&self) -> Result<(), AppError> {
         self.router.shutdown().await?;
 

--- a/cli/src/bin/reconnect.rs
+++ b/cli/src/bin/reconnect.rs
@@ -1,0 +1,43 @@
+use std::time::Duration;
+
+use cli::create_app_instance;
+
+use cli::CliError;
+
+/// Reconnect to all relays
+///
+/// This command disconnects all relays and then connects them again.
+#[tokio::main]
+pub async fn main() -> Result<(), CliError> {
+    env_logger::init();
+
+    let relays = vec![
+        "wss://relay.nostr.net".to_string(),
+        "wss://relay.damus.io".to_string(),
+    ];
+
+    let (keypair, app) = create_app_instance(
+        "Reconnect",
+        "mass derive myself benefit shed true girl orange family spawn device theme",
+        relays.clone(),
+    )
+    .await?;
+
+    // reconnect in 10 seconds
+
+    tokio::time::sleep(Duration::from_secs(7)).await;
+
+    log::info!("Reconnecting in 10 seconds");
+    // print 10 empty lines
+    for _ in 0..10 {
+        log::info!("");
+    }
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    app.reconnect().await?;
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    Ok(())
+}


### PR DESCRIPTION
Ref: #77 

**The Problem:**
When the app comes back from background:
- All relays are Disconnected
- Each relay's auto-reconnection loop wakes up
- Each relay [waits](https://github.com/rust-nostr/nostr/blob/ca0d48c77b0be17200ac456422687ee9a6481122/crates/nostr-relay-pool/src/relay/inner.rs#L562) for its retry interval + jitter
- They reconnect one by one because of different jitter delays

I created a function `reconnect` on the `PortalApp` to call when the app is reopened.