### PR TITLE
Refactor message router state

### DIFF
--- a/src/router/filters.rs
+++ b/src/router/filters.rs
@@ -1,17 +1,40 @@
 use nostr::filter::Filter;
 
 pub fn can_be_merged(filter1: &Filter, filter2: &Filter) -> bool {
-    filter1.kinds == filter2.kinds
+    filter1.kinds == filter2.kinds && filter1.generic_tags == filter2.generic_tags
 }
 
 pub fn merge_filters(filter1: &Filter, filter2: &Filter) -> Filter {
     let mut cloned = filter1.clone();
 
+    // Merge ids
+    if let Some(ids) = &mut cloned.ids {
+        if let Some(ids2) = &filter2.ids {
+            ids.extend(ids2.iter().cloned());
+        }
+    } else if let Some(ids2) = &filter2.ids {
+        cloned.ids = Some(ids2.clone());
+    }
     // Merge authors
     if let Some(authors) = &mut cloned.authors {
         if let Some(authors2) = &filter2.authors {
-            authors.extend(authors2);
+            authors.extend(authors2.iter().cloned());
         }
+    } else if let Some(authors2) = &filter2.authors {
+        cloned.authors = Some(authors2.clone());
+    }
+    // Merge since (take the minimum if both are Some)
+    match (cloned.since, filter2.since) {
+        (Some(s1), Some(s2)) => cloned.since = Some(std::cmp::min(s1, s2)),
+        (None, Some(s2)) => cloned.since = Some(s2),
+        _ => {}
+    }
+
+    // Merge until (take the maximum if both are Some)
+    match (cloned.until, filter2.until) {
+        (Some(u1), Some(u2)) => cloned.until = Some(std::cmp::max(u1, u2)),
+        (None, Some(u2)) => cloned.until = Some(u2),
+        _ => {}
     }
 
     cloned

--- a/src/router/filters.rs
+++ b/src/router/filters.rs
@@ -1,0 +1,18 @@
+use nostr::filter::Filter;
+
+pub fn can_be_merged(filter1: &Filter, filter2: &Filter) -> bool {
+    filter1.kinds == filter2.kinds
+}
+
+pub fn merge_filters(filter1: &Filter, filter2: &Filter) -> Filter {
+    let mut cloned = filter1.clone();
+
+    // Merge authors
+    if let Some(authors) = &mut cloned.authors {
+        if let Some(authors2) = &filter2.authors {
+            authors.extend(authors2);
+        }
+    }
+
+    cloned
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -15,6 +15,7 @@ use nostr::{
 pub mod actor;
 pub mod adapters;
 pub mod channel;
+pub mod filters;
 pub mod ids;
 
 pub use adapters::multi_key_listener::{MultiKeyListener, MultiKeyListenerAdapter};

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -24,18 +24,6 @@ pub use ids::PortalId;
 // Re-export MessageRouterActor as MessageRouter for backward compatibility
 pub use actor::{MessageRouterActor as MessageRouter, MessageRouterActorError};
 
-pub struct RelayNode {
-    conversations: HashSet<PortalId>,
-}
-
-impl RelayNode {
-    fn new() -> Self {
-        RelayNode {
-            conversations: HashSet::new(),
-        }
-    }
-}
-
 #[derive(Debug)]
 struct ResponseEntry {
     pub recepient_keys: Vec<PublicKey>,
@@ -205,6 +193,9 @@ pub enum ConversationError {
 
     #[error("Relay '{0}' is not connected")]
     RelayNotConnected(String),
+
+    #[error("Conversation not found")]
+    ConversationNotFound,
 }
 
 pub trait Conversation {


### PR DESCRIPTION
Thanks to the previous work #61 on the refactor of the MessageRouter, it can be improved by creating a `ConversationState` structure. 

This PR is in draft because I'm testing in the CLI, and because I think there's still room for improvement. 

This PR should lay the groundwork for simplifying issues #40 and #86 as well.