### PR TITLE
Rearchitecture app crate

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -11,6 +11,7 @@ use fetch_git_hash::fetch_git_hash;
 use bitcoin::{Network, bip32};
 use lightning_invoice::{Bolt11Invoice, ParseOrSemanticError};
 use std::{str::FromStr, time::UNIX_EPOCH};
+use tokio::sync::Mutex;
 
 use cdk_common::SECP256K1;
 use chrono::Duration;
@@ -23,7 +24,7 @@ use portal::{
             KeyHandshakeConversation,
         },
         payments::{
-            PaymentRequestContent, PaymentRequestEvent, PaymentRequestListenerConversation,
+            PaymentRequestContent, PaymentRequestListenerConversation,
             PaymentStatusSenderConversation, RecurringPaymentStatusSenderConversation,
         },
     },
@@ -48,9 +49,9 @@ use portal::{
             payment::{
                 CashuDirectContentWithKey, CashuRequestContentWithKey, CashuResponseContent,
                 CashuResponseStatus, CloseRecurringPaymentContent, CloseRecurringPaymentResponse,
-                InvoiceRequestContent, InvoiceRequestContentWithKey, InvoiceResponse,
-                PaymentResponseContent, RecurringPaymentRequestContent,
-                RecurringPaymentResponseContent, SinglePaymentRequestContent,
+                InvoiceRequestContent, InvoiceResponse, PaymentResponseContent,
+                RecurringPaymentRequestContent, RecurringPaymentResponseContent,
+                SinglePaymentRequestContent,
             },
         },
     },
@@ -173,7 +174,6 @@ impl From<bip39::Error> for MnemonicError {
     }
 }
 
-
 #[derive(uniffi::Object)]
 pub struct Nsec {
     keys: portal::nostr::Keys,
@@ -195,10 +195,10 @@ impl Nsec {
     }
 
     pub fn derive_cashu(&self) -> Vec<u8> {
-        use bitcoin::hashes::sha256;
         use bitcoin::hashes::Hash;
         use bitcoin::hashes::HashEngine;
-    
+        use bitcoin::hashes::sha256;
+
         let mut engine = sha256::HashEngine::default();
         engine.input(&self.keys.secret_key().secret_bytes());
         engine.input("cashu".as_bytes());
@@ -214,7 +214,6 @@ pub struct Keypair {
 
 #[uniffi::export]
 impl Keypair {
-
     pub fn public_key(&self) -> portal::protocol::model::bindings::PublicKey {
         portal::protocol::model::bindings::PublicKey(self.inner.public_key())
     }
@@ -268,6 +267,15 @@ pub struct PortalApp {
     router: Arc<MessageRouter<Arc<RelayPool>>>,
     relay_pool: Arc<RelayPool>,
     runtime: Arc<BindingsRuntime>,
+
+    auth_challenge_rx: Mutex<NotificationStream<portal::app::auth::AuthChallengeEvent>>,
+    payment_request_rx: Mutex<NotificationStream<portal::app::payments::PaymentRequestEvent>>,
+    closed_recurring_payment_rx:
+        Mutex<NotificationStream<portal::protocol::model::payment::CloseRecurringPaymentResponse>>,
+    invoice_request_rx:
+        Mutex<NotificationStream<portal::protocol::model::payment::InvoiceRequestContentWithKey>>,
+    cashu_request_rx: Mutex<NotificationStream<CashuRequestContentWithKey>>,
+    cashu_direct_rx: Mutex<NotificationStream<CashuDirectContentWithKey>>,
 }
 #[derive(uniffi::Record, Debug)]
 pub struct Bolt11InvoiceData {
@@ -341,106 +349,12 @@ pub enum CallbackError {
 
 #[uniffi::export(with_foreign)]
 #[async_trait::async_trait]
-pub trait AuthChallengeListener: Send + Sync {
-    async fn on_auth_challenge(
-        &self,
-        event: AuthChallengeEvent,
-    ) -> Result<AuthResponseStatus, CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait PaymentStatusNotifier: Send + Sync {
-    async fn notify(&self, status: PaymentResponseContent) -> Result<(), CallbackError>;
-}
-
-struct LocalStatusNotifier {
-    router: Arc<MessageRouter<Arc<RelayPool>>>,
-    request: PaymentRequestEvent,
-}
-
-#[async_trait::async_trait]
-impl PaymentStatusNotifier for LocalStatusNotifier {
-    async fn notify(&self, status: PaymentResponseContent) -> Result<(), CallbackError> {
-        let conv = PaymentStatusSenderConversation::new(
-            self.request.service_key.into(),
-            self.request.recipient.into(),
-            status,
-        );
-        self.router
-            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
-                self.request.recipient.into(),
-                vec![],
-                conv,
-            )))
-            .await
-            .map_err(|e| CallbackError::Error(e.to_string()))?;
-
-        Ok(())
-    }
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait PaymentRequestListener: Send + Sync {
-    async fn on_single_payment_request(
-        &self,
-        event: SinglePaymentRequest,
-        notifier: Arc<dyn PaymentStatusNotifier>,
-    ) -> Result<(), CallbackError>;
-    async fn on_recurring_payment_request(
-        &self,
-        event: RecurringPaymentRequest,
-    ) -> Result<RecurringPaymentResponseContent, CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait ClosedRecurringPaymentListener: Send + Sync {
-    async fn on_closed_recurring_payment(
-        &self,
-        event: CloseRecurringPaymentResponse,
-    ) -> Result<(), CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait InvoiceRequestListener: Send + Sync {
-    async fn on_invoice_requests(
-        &self,
-        event: InvoiceRequestContentWithKey,
-    ) -> Result<MakeInvoiceResponse, CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait InvoiceResponseListener: Send + Sync {
-    async fn on_invoice_response(&self, event: InvoiceResponse) -> Result<(), CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
 pub trait RelayStatusListener: Send + Sync {
     async fn on_relay_status_change(
         &self,
         relay_url: RelayUrl,
         status: RelayStatus,
     ) -> Result<(), CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait CashuRequestListener: Send + Sync {
-    async fn on_cashu_request(
-        &self,
-        event: CashuRequestContentWithKey,
-    ) -> Result<CashuResponseStatus, CallbackError>;
-}
-
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait CashuDirectListener: Send + Sync {
-    async fn on_cashu_direct(&self, event: CashuDirectContentWithKey) -> Result<(), CallbackError>;
 }
 
 #[uniffi::export]
@@ -495,10 +409,59 @@ impl PortalApp {
             router.add_relay(relay.clone(), false).await?;
         }
 
+        let auth_challenge_rx: NotificationStream<portal::app::auth::AuthChallengeEvent> = router
+            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                AuthChallengeListenerConversation::new(router.keypair().public_key()),
+                router.keypair().subkey_proof().cloned(),
+            )))
+            .await?;
+        let payment_request_rx: NotificationStream<portal::app::payments::PaymentRequestEvent> =
+            router
+                .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                    PaymentRequestListenerConversation::new(router.keypair().public_key()),
+                    router.keypair().subkey_proof().cloned(),
+                )))
+                .await?;
+        let closed_recurring_payment_rx: NotificationStream<
+            portal::protocol::model::payment::CloseRecurringPaymentResponse,
+        > = router
+            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                CloseRecurringPaymentReceiverConversation::new(router.keypair().public_key()),
+                router.keypair().subkey_proof().cloned(),
+            )))
+            .await?;
+        let invoice_request_rx: NotificationStream<
+            portal::protocol::model::payment::InvoiceRequestContentWithKey,
+        > = router
+            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                InvoiceReceiverConversation::new(router.keypair().public_key()),
+                router.keypair().subkey_proof().cloned(),
+            )))
+            .await?;
+        let cashu_request_rx: NotificationStream<CashuRequestContentWithKey> = router
+            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                CashuRequestReceiverConversation::new(router.keypair().public_key()),
+                router.keypair().subkey_proof().cloned(),
+            )))
+            .await?;
+        let cashu_direct_rx: NotificationStream<CashuDirectContentWithKey> = router
+            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
+                CashuDirectReceiverConversation::new(router.keypair().public_key()),
+                router.keypair().subkey_proof().cloned(),
+            )))
+            .await?;
+
         Ok(Arc::new(Self {
             router,
             relay_pool,
             runtime,
+
+            auth_challenge_rx: Mutex::new(auth_challenge_rx),
+            payment_request_rx: Mutex::new(payment_request_rx),
+            closed_recurring_payment_rx: Mutex::new(closed_recurring_payment_rx),
+            invoice_request_rx: Mutex::new(invoice_request_rx),
+            cashu_request_rx: Mutex::new(cashu_request_rx),
+            cashu_direct_rx: Mutex::new(cashu_direct_rx),
         }))
     }
 
@@ -606,109 +569,116 @@ impl PortalApp {
         Ok(())
     }
 
-    pub async fn listen_for_auth_challenge(
+    pub async fn next_auth_challenge(&self) -> Result<AuthChallengeEvent, AppError> {
+        let auth_challenge = self
+            .auth_challenge_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?
+            .map_err(|e| AppError::ParseError(e.to_string()))?;
+        log::debug!("Received auth challenge: {:?}", auth_challenge);
+        Ok(auth_challenge)
+    }
+
+    pub async fn reply_auth_challenge(
         &self,
-        evt: Arc<dyn AuthChallengeListener>,
+        event: AuthChallengeEvent,
+        status: AuthResponseStatus,
     ) -> Result<(), AppError> {
-        let inner = AuthChallengeListenerConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<portal::app::auth::AuthChallengeEvent> = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
+        let recipient = event.recipient.clone();
+
+        let conv = AuthResponseConversation::new(
+            event,
+            self.router.keypair().subkey_proof().cloned(),
+            status,
+        );
+        self.router
+            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
+                recipient.into(),
+                vec![],
+                conv,
             )))
             .await?;
-
-        while let Ok(response) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let evt = Arc::clone(&evt);
-            let router = Arc::clone(&self.router);
-
-            let _ = self.runtime.add_task(async move {
-                log::debug!("Received auth challenge: {:?}", response);
-
-                let status = evt.on_auth_challenge(response.clone()).await?;
-                log::debug!("Auth challenge callback result: {:?}", status);
-
-                let conv = AuthResponseConversation::new(
-                    response.clone(),
-                    router.keypair().subkey_proof().cloned(),
-                    status,
-                );
-                router
-                    .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
-                        response.recipient.into(),
-                        vec![],
-                        conv,
-                    )))
-                    .await?;
-
-                Ok::<(), AppError>(())
-            });
-        }
 
         Ok(())
     }
 
-    pub async fn listen_for_payment_request(
+    pub async fn next_payment_request(&self) -> Result<IncomingPaymentRequest, AppError> {
+        let request = self
+            .payment_request_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?;
+        let request = request.map_err(|e| AppError::ParseError(e.to_string()))?;
+
+        log::debug!("Received payment request: {:?}", request);
+
+        match &request.content {
+            PaymentRequestContent::Single(content) => {
+                Ok(IncomingPaymentRequest::Single(SinglePaymentRequest {
+                    service_key: request.service_key.clone(),
+                    recipient: request.recipient.clone(),
+                    expires_at: request.expires_at,
+                    content: content.clone(),
+                    event_id: request.event_id.clone(),
+                }))
+            }
+            PaymentRequestContent::Recurring(content) => {
+                Ok(IncomingPaymentRequest::Recurring(RecurringPaymentRequest {
+                    service_key: request.service_key.clone(),
+                    recipient: request.recipient.clone(),
+                    expires_at: request.expires_at,
+                    content: content.clone(),
+                    event_id: request.event_id.clone(),
+                }))
+            }
+        }
+    }
+
+    pub async fn reply_single_payment_request(
         &self,
-        evt: Arc<dyn PaymentRequestListener>,
+        request: SinglePaymentRequest,
+        status: PaymentResponseContent,
     ) -> Result<(), AppError> {
-        let inner = PaymentRequestListenerConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<portal::app::payments::PaymentRequestEvent> = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
+        let conv = PaymentStatusSenderConversation::new(
+            request.service_key.clone().into(),
+            request.recipient.clone().into(),
+            status,
+        );
+        let recipient = request.recipient.into();
+        self.router
+            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
+                recipient,
+                vec![],
+                conv,
             )))
             .await?;
 
-        while let Ok(request) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let evt = Arc::clone(&evt);
-            let router = Arc::clone(&self.router);
+        Ok(())
+    }
 
-            let _ = self.runtime.add_task(async move {
-                match &request.content {
-                    PaymentRequestContent::Single(content) => {
-                        let req = SinglePaymentRequest {
-                            service_key: request.service_key,
-                            recipient: request.recipient,
-                            expires_at: request.expires_at,
-                            content: content.clone(),
-                            event_id: request.event_id.clone(),
-                        };
-                        evt.on_single_payment_request(
-                            req,
-                            Arc::new(LocalStatusNotifier { router, request }),
-                        )
-                        .await?;
-                    }
-                    PaymentRequestContent::Recurring(content) => {
-                        let req = RecurringPaymentRequest {
-                            service_key: request.service_key,
-                            recipient: request.recipient,
-                            expires_at: request.expires_at,
-                            content: content.clone(),
-                            event_id: request.event_id.clone(),
-                        };
-                        let status = evt.on_recurring_payment_request(req).await?;
-                        let conv = RecurringPaymentStatusSenderConversation::new(
-                            request.service_key.into(),
-                            request.recipient.into(),
-                            status,
-                        );
-                        router
-                            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
-                                request.recipient.into(),
-                                vec![],
-                                conv,
-                            )))
-                            .await?;
-                    }
-                }
-
-                Ok::<(), AppError>(())
-            });
-        }
+    pub async fn reply_recurring_payment_request(
+        &self,
+        request: RecurringPaymentRequest,
+        status: RecurringPaymentResponseContent,
+    ) -> Result<(), AppError> {
+        let conv = RecurringPaymentStatusSenderConversation::new(
+            request.service_key.clone().into(),
+            request.recipient.clone().into(),
+            status,
+        );
+        let recipient = request.recipient.into();
+        self.router
+            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
+                recipient,
+                vec![],
+                conv,
+            )))
+            .await?;
 
         Ok(())
     }
@@ -793,34 +763,19 @@ impl PortalApp {
         Ok(())
     }
 
-    pub async fn listen_closed_recurring_payment(
+    pub async fn next_closed_recurring_payment(
         &self,
-        evt: Arc<dyn ClosedRecurringPaymentListener>,
-    ) -> Result<(), AppError> {
-        let inner =
-            CloseRecurringPaymentReceiverConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<
-            portal::protocol::model::payment::CloseRecurringPaymentResponse,
-        > = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
-            )))
-            .await?;
-
-        while let Ok(response) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let evt = Arc::clone(&evt);
-
-            let _ = self.runtime.add_task(async move {
-                log::debug!("Received closed recurring payment: {:?}", response);
-
-                let _ = evt.on_closed_recurring_payment(response).await?;
-
-                Ok::<(), AppError>(())
-            });
-        }
-        Ok(())
+    ) -> Result<CloseRecurringPaymentResponse, AppError> {
+        let response = self
+            .closed_recurring_payment_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?;
+        let response = response.map_err(|e| AppError::ParseError(e.to_string()))?;
+        log::debug!("Received closed recurring payment: {:?}", response);
+        Ok(response)
     }
 
     pub async fn add_relay(&self, url: String) -> Result<(), AppError> {
@@ -852,51 +807,42 @@ impl PortalApp {
         Ok(())
     }
 
-    pub async fn listen_invoice_requests(
+    pub async fn next_invoice_request(
         &self,
-        evt: Arc<dyn InvoiceRequestListener>,
+    ) -> Result<portal::protocol::model::payment::InvoiceRequestContentWithKey, AppError> {
+        let request = self
+            .invoice_request_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?;
+        let request = request.map_err(|e| AppError::ParseError(e.to_string()))?;
+        log::debug!("Received invoice request payment: {:?}", request);
+        Ok(request)
+    }
+
+    pub async fn reply_invoice_request(
+        &self,
+        request: portal::protocol::model::payment::InvoiceRequestContentWithKey,
+        invoice: MakeInvoiceResponse,
     ) -> Result<(), AppError> {
-        let inner = InvoiceReceiverConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<
-            portal::protocol::model::payment::InvoiceRequestContentWithKey,
-        > = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
+        let recipient = request.recipient.clone().into();
+        let invoice_response = InvoiceResponse {
+            request,
+            invoice: invoice.invoice,
+            payment_hash: invoice.payment_hash,
+        };
+
+        let conv = InvoiceSenderConversation::new(invoice_response);
+
+        self.router
+            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
+                recipient,
+                vec![],
+                conv,
             )))
             .await?;
-
-        while let Ok(request) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            log::debug!("Received invoice request payment: {:?}", request);
-
-            let recipient: nostr::key::PublicKey = request.recipient.into();
-
-            let evt = Arc::clone(&evt);
-            let router = Arc::clone(&self.router);
-
-            let _ = self.runtime.add_task(async move {
-                let invoice = evt.on_invoice_requests(request.clone()).await?;
-
-                let invoice_response = InvoiceResponse {
-                    request: request,
-                    invoice: invoice.invoice,
-                    payment_hash: invoice.payment_hash,
-                };
-
-                let conv = InvoiceSenderConversation::new(invoice_response);
-
-                router
-                    .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
-                        recipient.to_owned(),
-                        vec![],
-                        conv,
-                    )))
-                    .await?;
-
-                Ok::<(), AppError>(())
-            });
-        }
 
         Ok(())
     }
@@ -914,8 +860,7 @@ impl PortalApp {
         &self,
         recipient: PublicKey,
         content: InvoiceRequestContent,
-        evt: Arc<dyn InvoiceResponseListener>,
-    ) -> Result<(), AppError> {
+    ) -> Result<Option<InvoiceResponse>, AppError> {
         let conv = InvoiceRequestConversation::new(
             self.router.keypair().public_key(),
             self.router.keypair().subkey_proof().cloned(),
@@ -931,70 +876,53 @@ impl PortalApp {
             .await?;
 
         if let Ok(invoice_response) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let _ = evt.on_invoice_response(invoice_response.clone()).await?;
+            return Ok(Some(invoice_response));
         }
+        Ok(None)
+    }
+
+    pub async fn next_cashu_request(&self) -> Result<CashuRequestContentWithKey, AppError> {
+        let request = self
+            .cashu_request_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?;
+        let request = request.map_err(|e| AppError::ParseError(e.to_string()))?;
+        log::debug!("Received cashu request: {:?}", request);
+        Ok(request)
+    }
+
+    pub async fn reply_cashu_request(
+        &self,
+        request: CashuRequestContentWithKey,
+        status: CashuResponseStatus,
+    ) -> Result<(), AppError> {
+        let recipient = request.recipient.clone().into();
+        let response = CashuResponseContent { request, status };
+        let conv = CashuResponseSenderConversation::new(response);
+        self.router
+            .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
+                recipient,
+                vec![],
+                conv,
+            )))
+            .await?;
         Ok(())
     }
 
-    pub async fn listen_cashu_requests(
-        &self,
-        evt: Arc<dyn CashuRequestListener>,
-    ) -> Result<(), AppError> {
-        let inner = CashuRequestReceiverConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<CashuRequestContentWithKey> = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
-            )))
-            .await?;
-
-        while let Ok(request) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let evt = Arc::clone(&evt);
-            let router = Arc::clone(&self.router);
-            let _ = self.runtime.add_task(async move {
-                let status = evt.on_cashu_request(request.clone()).await?;
-
-                let recipient = request.recipient.into();
-                let response = CashuResponseContent {
-                    request: request,
-                    status: status,
-                };
-                let conv = CashuResponseSenderConversation::new(response);
-                router
-                    .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
-                        recipient,
-                        vec![],
-                        conv,
-                    )))
-                    .await?;
-                Ok::<(), AppError>(())
-            });
-        }
-        Ok(())
-    }
-
-    pub async fn listen_cashu_direct(
-        &self,
-        evt: Arc<dyn CashuDirectListener>,
-    ) -> Result<(), AppError> {
-        let inner = CashuDirectReceiverConversation::new(self.router.keypair().public_key());
-        let mut rx: NotificationStream<CashuDirectContentWithKey> = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
-                inner,
-                self.router.keypair().subkey_proof().cloned(),
-            )))
-            .await?;
-
-        while let Ok(response) = rx.next().await.ok_or(AppError::ListenerDisconnected)? {
-            let evt = Arc::clone(&evt);
-            let _ = self.runtime.add_task(async move {
-                let _ = evt.on_cashu_direct(response.clone()).await?;
-                Ok::<(), AppError>(())
-            });
-        }
-        Ok(())
+    pub async fn next_cashu_direct(&self) -> Result<CashuDirectContentWithKey, AppError> {
+        let response = self
+            .cashu_direct_rx
+            .lock()
+            .await
+            .next()
+            .await
+            .ok_or(AppError::ListenerDisconnected)?;
+        let response = response.map_err(|e| AppError::ParseError(e.to_string()))?;
+        log::debug!("Received cashu direct: {:?}", response);
+        Ok(response)
     }
 }
 
@@ -1109,7 +1037,7 @@ impl From<nostr_relay_pool::relay::RelayStatus> for RelayStatus {
     }
 }
 
-#[derive(Debug, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct SinglePaymentRequest {
     pub service_key: PublicKey,
     pub recipient: PublicKey,
@@ -1118,13 +1046,19 @@ pub struct SinglePaymentRequest {
     pub event_id: String,
 }
 
-#[derive(Debug, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct RecurringPaymentRequest {
     pub service_key: PublicKey,
     pub recipient: PublicKey,
     pub expires_at: Timestamp,
     pub content: RecurringPaymentRequestContent,
     pub event_id: String,
+}
+
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum IncomingPaymentRequest {
+    Single(SinglePaymentRequest),
+    Recurring(RecurringPaymentRequest),
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/cli/src/bin/cashu.rs
+++ b/cli/src/bin/cashu.rs
@@ -1,27 +1,10 @@
 use std::{sync::Arc, time::Duration as StdDuration};
 
-use app::{CallbackError, CashuRequestListener};
 use cli::{CliError, create_app_instance, create_sdk_instance};
 use portal::protocol::model::{
     Timestamp,
-    payment::{CashuRequestContent, CashuRequestContentWithKey, CashuResponseStatus},
+    payment::{CashuRequestContent, CashuResponseStatus},
 };
-
-struct LogCashuRequestListener;
-
-#[async_trait::async_trait]
-impl CashuRequestListener for LogCashuRequestListener {
-    async fn on_cashu_request(
-        &self,
-        event: CashuRequestContentWithKey,
-    ) -> Result<CashuResponseStatus, CallbackError> {
-        log::info!("Received Cashu request: {:?}", event);
-        // Always approve for test
-        Ok(CashuResponseStatus::Success {
-            token: "testtoken123".to_string(),
-        })
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), CliError> {
@@ -35,14 +18,32 @@ async fn main() -> Result<(), CliError> {
         relays.clone(),
     )
     .await?;
-    let _receiver = receiver.clone();
+    let receiver_loop = Arc::clone(&receiver);
 
     tokio::spawn(async move {
-        log::info!("Receiver: Setting up Cashu request listener");
-        _receiver
-            .listen_cashu_requests(Arc::new(LogCashuRequestListener))
-            .await
-            .expect("Receiver: Error creating listener");
+        log::info!("Receiver: Setting up Cashu request loop");
+        loop {
+            match receiver_loop.next_cashu_request().await {
+                Ok(event) => {
+                    log::info!("Receiver: Cashu request {:?}", event);
+                    if let Err(e) = receiver_loop
+                        .reply_cashu_request(
+                            event,
+                            CashuResponseStatus::Success {
+                                token: "testtoken123".to_string(),
+                            },
+                        )
+                        .await
+                    {
+                        log::error!("Receiver: Failed to reply to Cashu request: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Receiver: Cashu loop error: {:?}", e);
+                    break;
+                }
+            }
+        }
     });
 
     let sender_sdk = create_sdk_instance(

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -1,21 +1,18 @@
 use std::{io::Write, str::FromStr, sync::Arc};
 
 use app::{
-    AuthChallengeListener, CallbackError, CashuDirectListener, CashuRequestListener,
-    ClosedRecurringPaymentListener, Mnemonic, PaymentRequestListener, PaymentStatusNotifier,
-    PortalApp, RecurringPaymentRequest, RelayStatus, RelayStatusListener, RelayUrl,
-    SinglePaymentRequest, auth::AuthChallengeEvent, get_git_hash, nwc::NWC, parse_bolt11,
+    CallbackError, IncomingPaymentRequest, Mnemonic, PortalApp, RelayStatus, RelayStatusListener,
+    RelayUrl, SinglePaymentRequest, get_git_hash, nwc, nwc::NWC, parse_bolt11,
 };
-use log::info;
+use log::{error, info};
 use portal::{
-    nostr::nips::{nip19::ToBech32, nip47::PayInvoiceRequest},
+    nostr::nips::nip19::ToBech32,
     protocol::{
         key_handshake::KeyHandshakeUrl,
         model::{
             auth::AuthResponseStatus,
             payment::{
-                CashuDirectContentWithKey, CashuRequestContentWithKey, CashuResponseStatus,
-                CloseRecurringPaymentResponse, PaymentResponseContent, PaymentStatus,
+                CashuResponseStatus, PaymentResponseContent, PaymentStatus,
                 RecurringPaymentResponseContent, RecurringPaymentStatus,
             },
         },
@@ -37,138 +34,6 @@ impl RelayStatusListener for LogRelayStatusChange {
     }
 }
 
-struct ApproveLogin(Arc<PortalApp>);
-
-#[async_trait::async_trait]
-impl AuthChallengeListener for ApproveLogin {
-    async fn on_auth_challenge(
-        &self,
-        event: AuthChallengeEvent,
-    ) -> Result<AuthResponseStatus, CallbackError> {
-        log::info!("Received auth challenge: {:?}", event);
-
-        dbg!(self.0.fetch_profile(event.service_key).await);
-
-        Ok(AuthResponseStatus::Approved {
-            granted_permissions: vec![],
-            session_token: String::from("ABC"),
-        })
-    }
-}
-
-struct ApprovePayment(Arc<nwc::NWC>);
-
-#[async_trait::async_trait]
-impl PaymentRequestListener for ApprovePayment {
-    async fn on_single_payment_request(
-        &self,
-        event: SinglePaymentRequest,
-        notifier: Arc<dyn PaymentStatusNotifier>,
-    ) -> Result<(), CallbackError> {
-        log::info!("Received single payment request: {:?}", event);
-
-        notifier
-            .notify(PaymentResponseContent {
-                status: PaymentStatus::Approved,
-                request_id: event.content.request_id.clone(),
-            })
-            .await?;
-
-        let nwc = self.0.clone();
-        tokio::task::spawn(async move {
-            let payment_result = nwc
-                .pay_invoice(PayInvoiceRequest {
-                    id: None,
-                    invoice: event.content.invoice,
-                    amount: None,
-                })
-                .await;
-            log::info!("Payment result: {:?}", payment_result);
-
-            match payment_result {
-                Ok(payment) => {
-                    notifier
-                        .notify(PaymentResponseContent {
-                            status: PaymentStatus::Success {
-                                preimage: Some(payment.preimage),
-                            },
-                            request_id: event.content.request_id,
-                        })
-                        .await
-                        .unwrap();
-                }
-                Err(e) => {
-                    log::error!("Payment failed: {:?}", e);
-                    notifier
-                        .notify(PaymentResponseContent {
-                            status: PaymentStatus::Failed {
-                                reason: Some(e.to_string()),
-                            },
-                            request_id: event.content.request_id,
-                        })
-                        .await
-                        .unwrap();
-                }
-            }
-        });
-
-        Ok(())
-    }
-
-    async fn on_recurring_payment_request(
-        &self,
-        event: RecurringPaymentRequest,
-    ) -> Result<RecurringPaymentResponseContent, CallbackError> {
-        log::info!("Received recurring payment request: {:?}", event);
-        Ok(RecurringPaymentResponseContent {
-            status: RecurringPaymentStatus::Confirmed {
-                subscription_id: "randomid".to_string(),
-                authorized_amount: event.content.amount,
-                authorized_currency: event.content.currency,
-                authorized_recurrence: event.content.recurrence,
-            },
-            request_id: event.content.request_id,
-        })
-    }
-}
-
-struct LogClosedRecurringPayment;
-
-#[async_trait::async_trait]
-impl ClosedRecurringPaymentListener for LogClosedRecurringPayment {
-    async fn on_closed_recurring_payment(
-        &self,
-        event: CloseRecurringPaymentResponse,
-    ) -> Result<(), CallbackError> {
-        log::warn!("Received closed recurring payment: {:?}", event);
-        Ok(())
-    }
-}
-
-struct LogCashuRequestListener;
-
-#[async_trait::async_trait]
-impl CashuRequestListener for LogCashuRequestListener {
-    async fn on_cashu_request(
-        &self,
-        event: CashuRequestContentWithKey,
-    ) -> Result<CashuResponseStatus, CallbackError> {
-        log::info!("Received Cashu request: {:?}", event);
-        // Always approve for test
-        Ok(CashuResponseStatus::Success {
-            token: "testtoken123".to_string(),
-        })
-    }
-}
-
-#[async_trait::async_trait]
-impl CashuDirectListener for LogCashuRequestListener {
-    async fn on_cashu_direct(&self, event: CashuDirectContentWithKey) -> Result<(), CallbackError> {
-        log::info!("Received Cashu direct: {:?}", event);
-        Ok(())
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -184,10 +49,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Testing database so commented for now
     let nwc_str = std::env::var("CLI_NWC_URL").expect("CLI_NWC_URL is not set");
-    let nwc = NWC::new(nwc_str.parse()?, Arc::new(LogRelayStatusChange)).unwrap_or_else(|e| {
-        dbg!(e);
-        panic!();
-    });
+    let nwc = Arc::new(
+        NWC::new(nwc_str.parse()?, Arc::new(LogRelayStatusChange)).unwrap_or_else(|e| {
+            dbg!(e);
+            panic!();
+        }),
+    );
 
     log::info!(
         "Public key: {:?}",
@@ -244,39 +111,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     .await?
     // );
 
-    let _app = Arc::clone(&app);
+    let auth_app = Arc::clone(&app);
     tokio::spawn(async move {
-        _app.listen_for_auth_challenge(Arc::new(ApproveLogin(Arc::clone(&_app))))
-            .await
-            .unwrap();
+        auth_challenge_loop(auth_app).await;
     });
 
-    let _app = Arc::clone(&app);
+    let payment_app = Arc::clone(&app);
+    let payment_nwc = Arc::clone(&nwc);
     tokio::spawn(async move {
-        _app.listen_for_payment_request(Arc::new(ApprovePayment(Arc::new(nwc::NWC::new(nwc_str.parse().unwrap())))))
-            .await
-            .unwrap();
+        payment_request_loop(payment_app, payment_nwc).await;
     });
 
-    let _app = Arc::clone(&app);
+    let closed_app = Arc::clone(&app);
     tokio::spawn(async move {
-        _app.listen_closed_recurring_payment(Arc::new(LogClosedRecurringPayment))
-            .await
-            .unwrap();
+        closed_recurring_loop(closed_app).await;
     });
 
-    let _app = Arc::clone(&app);
+    let cashu_request_app = Arc::clone(&app);
     tokio::spawn(async move {
-        _app.listen_cashu_direct(Arc::new(LogCashuRequestListener))
-            .await
-            .unwrap();
+        cashu_request_loop(cashu_request_app).await;
     });
 
-    let _app = Arc::clone(&app);
+    let cashu_direct_app = Arc::clone(&app);
     tokio::spawn(async move {
-        _app.listen_cashu_requests(Arc::new(LogCashuRequestListener))
-            .await
-            .unwrap();
+        cashu_direct_loop(cashu_direct_app).await;
     });
 
     // let _app = Arc::clone(&app);
@@ -316,10 +174,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bolt11_invoice = Bolt11Invoice::from_str(invoice_str)?;
     let payment_hash_string = bolt11_invoice.payment_hash().to_string();
-    let result = nwc.lookup_invoice_from_payment_hash(payment_hash_string).await;
+    let result = nwc
+        .lookup_invoice_from_payment_hash(payment_hash_string)
+        .await;
     match result {
         Ok(lur) => {
-            info!("invoice from lookup_invoice_with_payment_hash -> {}", lur.invoice.unwrap());
+            info!(
+                "invoice from lookup_invoice_with_payment_hash -> {}",
+                lur.invoice.unwrap()
+            );
         }
         Err(e) => {
             info!("{}", e);
@@ -329,8 +192,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dbg!(get_git_hash());
     tokio::spawn(async move {
         const INVOICE: &str = "lnbc100n1p5fvqfdsp586d9yz88deyfxm2mxgh39n39lezmpnkcv0a35uh38fvnjzlaxdzqpp59nwc8zac6psv09wysxvulgwj0t23jh3g5r4l5qzgpdsnel94w5zshp5mndu23huxkp6jgynf8agfjfaypgfjs2z8glq8fs9zqjfpnf34jnqcqpjrzjqgc7enr9zr4ju8yhezsep4h2p9ncf2nuxkp423pq2k4v3vsx2nunyz60tsqqj9qqqqqqqqqpqqqqqysqjq9qxpqysgqala28sswmp68uc9axqt893n48lzzt7l3uzkzjzlmlzurczpc647sxn4vrt4hvm30v5vv2ysvxhxeej78j903emrrjh02xdrl6z9alzqqns0w5s";
-        let invoice_data = parse_bolt11(INVOICE);
-        dbg!(invoice_data);
+        match parse_bolt11(INVOICE) {
+            Ok(invoice_data) => {
+                dbg!(invoice_data);
+            }
+            Err(e) => {
+                error!("Failed to parse bolt11 invoice: {:?}", e);
+            }
+        }
     });
 
     println!("\nEnter the auth init URL:");
@@ -344,4 +213,155 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::time::sleep(std::time::Duration::from_secs(600)).await;
 
     Ok(())
+}
+
+async fn auth_challenge_loop(app: Arc<PortalApp>) {
+    loop {
+        match app.next_auth_challenge().await {
+            Ok(event) => {
+                info!("Received auth challenge: {:?}", event);
+                let _ = app.fetch_profile(event.service_key.clone()).await;
+                let status = AuthResponseStatus::Approved {
+                    granted_permissions: vec![],
+                    session_token: String::from("ABC"),
+                };
+                if let Err(e) = app.reply_auth_challenge(event, status).await {
+                    error!("Failed to reply to auth challenge: {:?}", e);
+                }
+            }
+            Err(e) => {
+                error!("Auth challenge loop error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn payment_request_loop(app: Arc<PortalApp>, nwc: Arc<nwc::NWC>) {
+    loop {
+        match app.next_payment_request().await {
+            Ok(IncomingPaymentRequest::Single(request)) => {
+                info!("Received single payment request: {:?}", request);
+                let single_app = Arc::clone(&app);
+                let single_nwc = Arc::clone(&nwc);
+                tokio::spawn(async move {
+                    process_single_payment_request(single_app, single_nwc, request).await;
+                });
+            }
+            Ok(IncomingPaymentRequest::Recurring(request)) => {
+                info!("Received recurring payment request: {:?}", request);
+                let content = request.content.clone();
+                let status = RecurringPaymentResponseContent {
+                    status: RecurringPaymentStatus::Confirmed {
+                        subscription_id: "randomid".to_string(),
+                        authorized_amount: content.amount,
+                        authorized_currency: content.currency,
+                        authorized_recurrence: content.recurrence,
+                    },
+                    request_id: content.request_id,
+                };
+                if let Err(e) = app.reply_recurring_payment_request(request, status).await {
+                    error!("Failed to reply to recurring payment request: {:?}", e);
+                }
+            }
+            Err(e) => {
+                error!("Payment request loop error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn process_single_payment_request(
+    app: Arc<PortalApp>,
+    nwc: Arc<nwc::NWC>,
+    request: SinglePaymentRequest,
+) {
+    if let Err(e) = app
+        .reply_single_payment_request(
+            request.clone(),
+            PaymentResponseContent {
+                status: PaymentStatus::Approved,
+                request_id: request.content.request_id.clone(),
+            },
+        )
+        .await
+    {
+        error!("Failed to send approval for payment request: {:?}", e);
+        return;
+    }
+
+    let payment_result = nwc.pay_invoice(request.content.invoice.clone()).await;
+    info!("Payment result: {:?}", payment_result);
+
+    let status = match payment_result {
+        Ok(preimage) => PaymentResponseContent {
+            status: PaymentStatus::Success {
+                preimage: Some(preimage),
+            },
+            request_id: request.content.request_id.clone(),
+        },
+        Err(e) => {
+            error!("Payment failed: {:?}", e);
+            PaymentResponseContent {
+                status: PaymentStatus::Failed {
+                    reason: Some(e.to_string()),
+                },
+                request_id: request.content.request_id.clone(),
+            }
+        }
+    };
+
+    if let Err(e) = app.reply_single_payment_request(request, status).await {
+        error!("Failed to send payment status update: {:?}", e);
+    }
+}
+
+async fn closed_recurring_loop(app: Arc<PortalApp>) {
+    loop {
+        match app.next_closed_recurring_payment().await {
+            Ok(event) => info!("Received closed recurring payment: {:?}", event),
+            Err(e) => {
+                error!("Closed recurring payment loop error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn cashu_request_loop(app: Arc<PortalApp>) {
+    loop {
+        match app.next_cashu_request().await {
+            Ok(event) => {
+                info!("Received Cashu request: {:?}", event);
+                if let Err(e) = app
+                    .reply_cashu_request(
+                        event,
+                        CashuResponseStatus::Success {
+                            token: "testtoken123".to_string(),
+                        },
+                    )
+                    .await
+                {
+                    error!("Failed to reply to Cashu request: {:?}", e);
+                }
+            }
+            Err(e) => {
+                error!("Cashu request loop error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn cashu_direct_loop(app: Arc<PortalApp>) {
+    loop {
+        match app.next_cashu_direct().await {
+            Ok(event) => info!("Received Cashu direct: {:?}", event),
+            Err(e) => {
+                error!("Cashu direct loop error: {:?}", e);
+                break;
+            }
+        }
+    }
 }

--- a/rest/src/command.rs
+++ b/rest/src/command.rs
@@ -1,8 +1,9 @@
 use portal::profile::Profile;
-use portal::protocol::model::Timestamp;
 use portal::protocol::model::payment::{
-    Currency, InvoiceRequestContent, RecurrenceInfo, RecurringPaymentRequestContent, SinglePaymentRequestContent
+    Currency, InvoiceRequestContent, RecurrenceInfo, RecurringPaymentRequestContent,
+    SinglePaymentRequestContent,
 };
+use portal::protocol::model::Timestamp;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -22,7 +23,6 @@ pub enum Command {
     },
 
     // SDK methods
-
     NewKeyHandshakeUrl {
         static_token: Option<String>,
         no_request: Option<bool>,
@@ -117,10 +117,9 @@ pub struct SinglePaymentParams {
     pub amount: u64,
     pub currency: Currency,
     pub auth_token: Option<String>,
-    
+
     pub subscription_id: Option<String>,
 }
-
 
 #[derive(Debug, Deserialize)]
 pub struct RecurringPaymentParams {

--- a/rest/src/response.rs
+++ b/rest/src/response.rs
@@ -1,8 +1,8 @@
 use nostr::nips::nip05::Nip05Profile;
 use portal::profile::Profile;
-use portal::protocol::model::Timestamp;
 use portal::protocol::model::auth::AuthResponseStatus;
 use portal::protocol::model::payment::{CashuResponseStatus, RecurringPaymentResponseContent};
+use portal::protocol::model::Timestamp;
 use serde::Serialize;
 
 // Response structs for each API

--- a/rest/src/ws.rs
+++ b/rest/src/ws.rs
@@ -20,7 +20,8 @@ use portal::nostr_relay_pool::RelayOptions;
 use portal::protocol::calendar::Calendar;
 use portal::protocol::jwt::CustomClaims;
 use portal::protocol::model::payment::{
-    CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, PaymentStatus, RecurringPaymentRequestContent, SinglePaymentRequestContent
+    CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, PaymentStatus,
+    RecurringPaymentRequestContent, SinglePaymentRequestContent,
 };
 use portal::protocol::model::Timestamp;
 use rand::RngCore;
@@ -441,7 +442,12 @@ async fn handle_command(command: CommandWithId, ctx: Arc<SocketContext>) {
                         });
                     }
                     Err(e) => {
-                        let _ = ctx.send_error_message(&command.id, &format!("Failed to fetch market data: {}", e)).await;
+                        let _ = ctx
+                            .send_error_message(
+                                &command.id,
+                                &format!("Failed to fetch market data: {}", e),
+                            )
+                            .await;
                         return;
                     }
                 }
@@ -520,7 +526,6 @@ async fn handle_command(command: CommandWithId, ctx: Arc<SocketContext>) {
             let amount = payment_request.amount;
             let mut msat_amount = payment_request.amount;
 
-
             // If the currency is fiat, we need to convert it to millisats
             let mut current_exchange_rate = None;
             if let Currency::Fiat(currency) = &payment_request.currency {
@@ -528,7 +533,7 @@ async fn handle_command(command: CommandWithId, ctx: Arc<SocketContext>) {
                 let market_data = ctx.market_api.clone().fetch_market_data(&currency).await;
                 match market_data {
                     Ok(market_data) => {
-                        msat_amount = market_data.calculate_millisats(fiat_amount) as u64;                        
+                        msat_amount = market_data.calculate_millisats(fiat_amount) as u64;
                         current_exchange_rate = Some(ExchangeRate {
                             rate: market_data.rate,
                             source: market_data.source,
@@ -536,19 +541,20 @@ async fn handle_command(command: CommandWithId, ctx: Arc<SocketContext>) {
                         });
                     }
                     Err(e) => {
-                        let _ = ctx.send_error_message(&command.id, &format!("Failed to fetch market data: {}", e)).await;
+                        let _ = ctx
+                            .send_error_message(
+                                &command.id,
+                                &format!("Failed to fetch market data: {}", e),
+                            )
+                            .await;
                         return;
                     }
                 }
             }
 
-
             // TODO: fetch and apply fiat exchange rate
             let invoice = match wallet
-                .make_invoice(
-                    msat_amount,
-                    Some(payment_request.description.clone()),
-                )
+                .make_invoice(msat_amount, Some(payment_request.description.clone()))
                 .await
             {
                 Ok(invoice) => invoice,
@@ -1446,7 +1452,9 @@ async fn handle_command(command: CommandWithId, ctx: Arc<SocketContext>) {
             let calendar = match Calendar::from_str(&calendar) {
                 Ok(calendar) => calendar,
                 Err(e) => {
-                    let _ = ctx.send_error_message(&command.id, &format!("Invalid calendar: {}", e)).await;
+                    let _ = ctx
+                        .send_error_message(&command.id, &format!("Invalid calendar: {}", e))
+                        .await;
                     return;
                 }
             };

--- a/src/protocol/calendar.rs
+++ b/src/protocol/calendar.rs
@@ -518,7 +518,10 @@ impl Calendar {
             && matches!(self.day, TimeComponent::Any)
             && matches!(self.hour, TimeComponent::Any)
         {
-            if let TimeComponent::Range { step: Some(step), .. } = &self.minute {
+            if let TimeComponent::Range {
+                step: Some(step), ..
+            } = &self.minute
+            {
                 return Some(format!("Every {} minutes", step));
             }
         }
@@ -527,13 +530,19 @@ impl Calendar {
             && matches!(self.month, TimeComponent::Any)
             && matches!(self.day, TimeComponent::Any)
         {
-            if let TimeComponent::Range { step: Some(step), .. } = &self.hour {
+            if let TimeComponent::Range {
+                step: Some(step), ..
+            } = &self.hour
+            {
                 return Some(format!("Every {} hours", step));
             }
         }
 
         if matches!(self.year, TimeComponent::Any) && matches!(self.month, TimeComponent::Any) {
-            if let TimeComponent::Range { step: Some(step), .. } = &self.day {
+            if let TimeComponent::Range {
+                step: Some(step), ..
+            } = &self.day
+            {
                 return Some(format!("Every {} days", step));
             }
         }
@@ -1093,8 +1102,6 @@ mod tests {
                 .unwrap()
                 .with_timezone(&chrono_tz::Europe::Rome)
         );
-
-
     }
 
     #[test]
@@ -1286,10 +1293,7 @@ mod tests {
             second: TimeComponent::Values(vec![0]),
             timezone: None,
         };
-        assert_eq!(
-            cal_every_10.to_human_readable(true),
-            "Every 10 minutes"
-        );
+        assert_eq!(cal_every_10.to_human_readable(true), "Every 10 minutes");
 
         let cal_every_6h = Calendar {
             weekdays: None,
@@ -1305,10 +1309,7 @@ mod tests {
             second: TimeComponent::Values(vec![0]),
             timezone: None,
         };
-        assert_eq!(
-            cal_every_6h.to_human_readable(true),
-            "Every 6 hours"
-        );
+        assert_eq!(cal_every_6h.to_human_readable(true), "Every 6 hours");
 
         let cal_every_3d = Calendar {
             weekdays: None,

--- a/src/router/actor.rs
+++ b/src/router/actor.rs
@@ -1089,7 +1089,7 @@ struct ConversationState {
 #[derive(Debug)]
 enum InnerConversationState {
     Standard(ConversationBox),
-    Alias
+    Alias,
 }
 
 impl InnerConversationState {
@@ -1230,7 +1230,10 @@ impl ConversationState {
                 Err(mpsc::error::SendError(_)) => {
                     // Channel is closed, remove dead subscriber
                     // Do not push to alive_subscribers
-                    log::warn!("Removing subscriber from conversation {} because channel is closed", self.id);
+                    log::warn!(
+                        "Removing subscriber from conversation {} because channel is closed",
+                        self.id
+                    );
                 }
             }
         }

--- a/wallet/src/breez.rs
+++ b/wallet/src/breez.rs
@@ -81,7 +81,10 @@ impl PortalWallet for BreezSparkWallet {
                         ..
                     }) => {
                         if invoice == *payment_invoice {
-                            return Ok((payment.status == PaymentStatus::Completed, preimage.clone()));
+                            return Ok((
+                                payment.status == PaymentStatus::Completed,
+                                preimage.clone(),
+                            ));
                         }
                     }
                     _ => {}


### PR DESCRIPTION
Instead of getting a callback from the app to call with each incoming request, we split each function in a "pull" and "push" methods: one is used to get the next request, and can be called as many times as needed even in parallel. The other method is used to send a reply once it's available.

This effectively allows replying to requests that were received in a previous run of the app, as long as we persist the request id somewhere in the app. We can for example receive a request before the user closes the app, and then the next time it's opened we re-present the pending request (as long as it's not expired yet) and through the "push" method we can later reply.

This should also fix a few weird issues we encountered with react stuff not being updated inside the listeners. I believe this was caused by the interaction between rust, the bindings and react native. This should all be fixed now.