### PR TITLE
docs: add CHANGELOG.md for portal-app and portal-rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,134 @@
+# Changelog
+
+All notable changes to Portal libraries will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## portal-rest (SDK Daemon)
+
+### Unreleased
+
+#### Added
+- `PayInvoice` WebSocket command
+- `GetWalletInfo` command and TypeScript SDK client
+
+#### Changed
+- Default Breez storage directory changed to `~/.portal-rest/breez`
+- Removed unused dependencies (`dotenv`, `bitflags`, `android_logger`, `async`); workspace deps centralized and reorganized
+- Updated Breez SDK
+
+#### Fixed
+- Cargo warnings cleanup
+
+---
+
+### [0.1.0] - 2026-02-09
+
+First release — Docker image available at [`getportal/sdk-daemon`](https://hub.docker.com/r/getportal/sdk-daemon).
+
+#### Added
+- WebSocket-based daemon for interacting with the Portal protocol
+- Commands: `RequestRecurringPayment`, `RequestSinglePayment`
+- Commands: `FetchNip05Profile`, `CalculateNextOccurrence`
+- Fiat currency support in payment requests (with exchange rate source reporting)
+- Relay management: `AddRelay`, `RemoveRelay`; report user's preferred relays to clients
+- NIP-46 bunker support
+- TOML configuration file support with env variable overrides
+- Versioning endpoint (reports build commit hash)
+- Docker and NixOS module (`module.nix`) for deployment
+
+#### Fixed
+- Secrets no longer logged
+
+---
+
+## portal-app (App Library)
+
+### Unreleased
+
+---
+
+### [0.4.13] - 2026-01-27
+
+---
+
+### [0.4.12] - 2025-12-08
+
+---
+
+### [0.4.11] - 2025-12-02
+
+---
+
+### [0.4.10] - 2025-11-11
+
+---
+
+### [0.4.9] - 2025-11-04
+
+---
+
+### [0.4.8] - 2025-10-30
+
+---
+
+### [0.4.7] - 2025-10-07
+
+---
+
+### [0.4.6] - 2025-09-23
+
+---
+
+### [0.4.5] - 2025-09-18
+
+Releasing a new version to include iOS build on npm. No relevant updates are in this release.
+
+---
+
+### [0.4.4] - 2025-09-10
+
+- Fixing profile conversation expiring check
+
+---
+
+### [0.4.3] - 2025-09-04
+
+- Only set preferred relays in key handshake urls
+- Expose missing expiration
+
+---
+
+### [0.4.2] - 2025-08-22
+
+- Update nostr git dep to include fixes for NWC
+
+---
+
+### [0.4.1] - 2025-08-13
+
+- Connect relays in URL
+- LNURL parsing
+- Reconnect relay NWC
+
+---
+
+### [0.4.0] - 2025-08-01
+
+- Update nostr to 0.43
+
+---
+
+### [0.3.1] - 2025-08-01
+
+- Make the relay reconnection parallel and not sequential
+- Disable automatic relay reconnection
+
+---
+
+### [0.3.0] - 2025-08-01
+
+- Use binary cache to build the library
+- Send multiple notifications for single payments

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-portaltechnologiesinc.github.io-blue)](https://portaltechnologiesinc.github.io/lib/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)
 
 Portal is a Nostr-based authentication and payment SDK allowing applications to authenticate users and process payments through Nostr and Lightning Network.
 
@@ -39,4 +40,4 @@ Then use `ws://localhost:3000/ws` and your token with the [TypeScript](https://w
 
 ---
 
-**License:** MIT — [LICENSE](LICENSE)
+**License:** MIT — [LICENSE](LICENSE) | **Changelog:** [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
Adds a `CHANGELOG.md` at workspace root tracking release history for:

- **portal-rest**: from `0.1.0` (first Docker release)
- **portal-app**: from `0.4.0` to `0.4.13`

Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Draft generated from git history between tags — feel free to refine entries.