### PR TITLE
fix: add CA certificates to rest-docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,8 @@
             name = "getportal/sdk-daemon";
             tag = if system == "x86_64-linux" then "amd64" else "arm64";
 
+            contents = [ pkgs.cacert ];
+
             config = {
               Cmd = [ "${minimal-closure}/bin/rest" ];
               ExposedPorts = {
@@ -129,6 +131,7 @@
               Env = [
                 "PORTAL__INFO__LISTEN_PORT=3000"
                 "RUST_LOG=portal=debug,rest=debug,info"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
             };
           };


### PR DESCRIPTION
Fixes #147

## Problem
The  Nix image had no CA certificates, causing all outbound HTTPS requests (NIP-05 fetches, Breez/Spark APIs, etc.) to fail with a TLS certificate verification error.

## Fix
- Added `pkgs.cacert` to the image `contents`
- Set `SSL_CERT_FILE` env var so Rust's TLS stack (reqwest/rustls) knows where to find the certificate bundle