### PR TITLE
fix: return fees_paid_msat from NWC pay_invoice uniffi binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "async-trait",
  "async-utility",

--- a/crates/portal-app/Cargo.toml
+++ b/crates/portal-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2024"
 
 [lib]

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-app-lib",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "React Native bindings for the Portal App library",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
## Problem

The `portal-app` uniffi binding for `NWC.pay_invoice` was returning only the preimage string, silently discarding the `fees_paid` field from the NIP-47 response:

```rust
// before
pub async fn pay_invoice(&self, invoice: String) -> Result<String, AppError> {
    let response = self.inner.pay_invoice(...).await?;
    Ok(response.preimage) // fees_paid thrown away
}
```

This meant `NwcService.sendPayment` in portal-app had no way to surface NWC payment fees — it always returned `{ preimage }` with no `feeSats`, so the activity detail screen always showed "N/A" for fees on NWC payments.

## Root Cause

The internal `portal-wallet` `NwcWallet` trait was already updated in #149 to return `(preimage, fees_paid_msat)` — but that change lives in the `portal-rest` websocket server path. The `portal-app` uniffi binding (`crates/portal-app/src/nwc.rs`) is a separate code path used by the React Native client directly, and was not updated.

## Fix

Introduce a `PayInvoiceResult` record (uniffi does not support tuple return types) containing both `preimage` and `fees_paid_msat`, and return it from the uniffi-exported `pay_invoice`:

```rust
#[derive(uniffi::Record)]
pub struct PayInvoiceResult {
    pub preimage: String,
    /// Fees in millisatoshis. Zero if the NWC wallet did not report fees (NIP-47 fees_paid is optional).
    pub fees_paid_msat: u64,
}
```

`fees_paid` is `Option<u64>` in the NIP-47 response, so we default to `0` when absent.

## Portal-app side

After this lib version is published, `NwcService.sendPayment` in portal-app can be updated to:

```typescript
const result = await this.client.payInvoice(paymentRequest);
return {
  preimage: result.preimage,
  feeSats: Math.floor(result.fees_paid_msat / 1000),
};
```
