### PR TITLE
docs: rewrite README + fix remaining version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,107 @@
 # Portal
 
 [![Documentation](https://img.shields.io/badge/docs-portaltechnologiesinc.github.io-blue)](https://portaltechnologiesinc.github.io/lib/)
-[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)
+[![Docker](https://img.shields.io/docker/v/getportal/sdk-daemon?label=sdk-daemon&color=blue)](https://hub.docker.com/r/getportal/sdk-daemon)
 
-Portal is a Nostr-based authentication and payment SDK allowing applications to authenticate users and process payments through Nostr and Lightning Network.
+**Portal is the identity and payment layer for Bitcoin-native applications — no accounts, no KYC, no payment processor.**
 
-**Documentation:** [portaltechnologiesinc.github.io/lib](https://portaltechnologiesinc.github.io/lib/)
+Users interact through the Portal mobile app using their Nostr identity. You run a single Docker container and talk to it with our SDK.
 
 ---
 
-## Repository
+## How it works
 
-| Crate / package | Description |
-|-----------------|-------------|
-| portal-rest | API server (REST + WebSocket). Run with Docker or from source. |
-| portal | Core protocol and conversation logic. |
-| portal-app | App runtime and wallet integration. |
-| portal-cli | CLI tools (JWT, invoices, Cashu, etc.). |
-| portal-wallet | Wallet backends (NWC, Breez). |
-| portal-rates | Fiat exchange rates for BTC/sats. |
-| clients/ts | TypeScript SDK ([npm](https://www.npmjs.com/package/portal-sdk)). |
-| Java SDK | [PortalTechnologiesInc/java-sdk](https://github.com/PortalTechnologiesInc/java-sdk). |
+```
+Your backend  ←—WebSocket—→  sdk-daemon  ←—Nostr relays—→  Portal app (user's phone)
+```
+
+1. Your backend asks sdk-daemon for a handshake URL → show it as a QR code
+2. User scans with Portal app → you receive their Nostr public key
+3. Your backend requests a payment (sats or fiat) → user approves in app → Lightning settlement
+
+---
 
 ## Quick start
 
-**Run the API (Docker):**
+**1. Run sdk-daemon**
 
 ```bash
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=your-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:latest
+  getportal/sdk-daemon:0.3.0
 ```
 
-Then use `ws://localhost:3000/ws` and your token with the [TypeScript](https://www.npmjs.com/package/portal-sdk) or [Java](https://github.com/PortalTechnologiesInc/java-sdk) SDK. See [Quick Start](https://portaltechnologiesinc.github.io/lib/getting-started/quick-start.html) in the docs.
+**2. Install the SDK**
 
-**Build from source:** [Building from source](https://portaltechnologiesinc.github.io/lib/getting-started/building-from-source.html) — `cargo build --package portal-rest --release` or `nix build .#rest`.
+```bash
+npm install portal-sdk          # TypeScript / JavaScript
+```
+
+```groovy
+// Java (Gradle) — via JitPack
+implementation 'com.github.PortalTechnologiesInc:java-sdk:0.3.0'
+```
+
+**3. Connect and authenticate a user**
+
+```typescript
+import { PortalSDK } from 'portal-sdk';
+
+const client = new PortalSDK({ serverUrl: 'ws://localhost:3000/ws' });
+await client.connect();
+await client.authenticate('your-secret-token');
+
+const url = await client.newKeyHandshakeUrl((userKey) => {
+  console.log('User authenticated:', userKey);
+});
+// Show `url` as a QR code to the user
+```
 
 ---
 
-**License:** MIT — [LICENSE](LICENSE) | **Changelog:** [CHANGELOG.md](CHANGELOG.md)
+## SDK versions
+
+| SDK | Version | Install |
+|-----|---------|---------|
+| TypeScript / JavaScript | `0.3.0` | `npm install portal-sdk` |
+| Java | `0.3.0` | [JitPack](https://jitpack.io/#PortalTechnologiesInc/java-sdk) |
+| Docker image | `0.3.0` | `docker pull getportal/sdk-daemon:0.3.0` |
+
+The SDK `major.minor` version must match the daemon. Patch versions are independent. See [Versioning & Compatibility](https://portaltechnologiesinc.github.io/lib/getting-started/versioning.html).
+
+---
+
+## What you can do
+
+- **Authenticate users** — passwordless login via Nostr identity
+- **Request payments** — single, recurring, or invoice-based; BTC (sats) or fiat (EUR, USD, and [more](https://portaltechnologiesinc.github.io/lib/sdk/api-reference.html))
+- **Issue JWTs** — signed by the user's Nostr key, verifiable server-side
+- **Cashu tokens** — mint, burn, and transfer ecash
+- **NWC wallet** — connect any NWC-compatible wallet for outbound payments
+
+---
+
+## This repository
+
+| Package | Description |
+|---------|-------------|
+| `portal-rest` | SDK Daemon — HTTP + WebSocket API server |
+| `portal` | Core Nostr protocol and conversation logic |
+| `portal-app` | App runtime and wallet integration |
+| `portal-wallet` | Wallet backends (NWC, Breez) |
+| `portal-rates` | Fiat/BTC exchange rates |
+| `clients/ts` | TypeScript SDK source |
+| `portal-cli` | CLI tools for development and testing |
+
+---
+
+## Documentation
+
+Full docs at **[portaltechnologiesinc.github.io/lib](https://portaltechnologiesinc.github.io/lib/)** — guides for authentication, payments, Cashu, JWT, relay setup, Docker deployment, and more.
+
+---
+
+**License:** MIT · [Java SDK](https://github.com/PortalTechnologiesInc/java-sdk) · [Demo](https://github.com/PortalTechnologiesInc/portal-demo)

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -195,7 +195,7 @@ docker run -d --name portal-sdk-daemon \
   -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=$PORTAL__AUTH__AUTH_TOKEN \
   -e PORTAL__NOSTR__PRIVATE_KEY=$PORTAL__NOSTR__PRIVATE_KEY \
-  getportal/sdk-daemon:latest
+  getportal/sdk-daemon:0.3.0
 ```
 
 ### Health Check Failing
@@ -312,7 +312,7 @@ For Docker daemon:
 docker run -d \
   -e RUST_LOG=debug \
   ...
-  getportal/sdk-daemon:latest
+  getportal/sdk-daemon:0.3.0
 
 # View debug logs
 docker logs -f portal-sdk-daemon

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -49,7 +49,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.2.1'
+    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.3.0'
 }
 ```
 
@@ -63,7 +63,7 @@ dependencies {
 <dependency>
     <groupId>com.github.PortalTechnologiesInc</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
 </dependency>
 ```
 
@@ -83,7 +83,7 @@ See [SDK Installation](../sdk/installation.md).
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=my-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:latest
+  getportal/sdk-daemon:0.3.0
 ```
 
 Check: curl http://localhost:3000/health → OK. Use ws://localhost:3000/ws and token my-secret-token.


### PR DESCRIPTION
## Changes

### README.md — full rewrite
- Clear one-liner explaining what Portal is
- Architecture diagram (ascii) showing the flow
- 3-step quick start (Docker → install SDK → first call)
- SDK versions table with install commands
- "What you can do" section (auth, payments, JWT, Cashu, NWC)
- Repo contents table
- Single docs link at the bottom

### Version fixes
- `docs/getting-started/quick-start.md`: `0.2.1` → `0.3.0`, `:latest` → `0.3.0`
- `docs/advanced/troubleshooting.md`: `sdk-daemon:latest` → `sdk-daemon:0.3.0` (2 occurrences)