### PR TITLE
feat(portal-app-demo): add key handshake approval UI and endpoint

### DIFF
--- a/crates/portal-app-demo/src/index.html
+++ b/crates/portal-app-demo/src/index.html
@@ -99,6 +99,14 @@
       </div>
     </section>
 
+    <section id="handshake-section" style="display:none;">
+      <h2 style="font-size:1rem; margin:0 0 0.75rem;">Approve login</h2>
+      <label for="handshake-url">Key handshake URL</label>
+      <textarea id="handshake-url" placeholder="portal-handshake://..."></textarea>
+      <button type="button" id="btn-handshake">Approve</button>
+      <p id="handshake-status" class="status" style="margin-top:0.5rem;"></p>
+    </section>
+
     <section id="payment-section" style="display:none;">
       <h2 style="font-size:1rem; margin:0 0 0.5rem;">Payment request</h2>
       <p class="status">Waiting for a single payment request…</p>
@@ -155,6 +163,10 @@
     const paymentActions = document.getElementById('payment-actions');
     const btnAccept = document.getElementById('btn-accept');
     const btnReject = document.getElementById('btn-reject');
+    const handshakeSection = document.getElementById('handshake-section');
+    const handshakeUrl = document.getElementById('handshake-url');
+    const btnHandshake = document.getElementById('btn-handshake');
+    const handshakeStatus = document.getElementById('handshake-status');
     const invoiceRequestSection = document.getElementById('invoice-request-section');
     const invoiceRequestPending = document.getElementById('invoice-request-pending');
     const invoiceRequestPendingCard = document.getElementById('invoice-request-pending-card');
@@ -183,6 +195,7 @@
             walletBalance.style.display = 'none';
           }
           walletPubkeyWrap.style.display = 'block';
+          handshakeSection.style.display = 'block';
           paymentSection.style.display = 'block';
           invoiceRequestSection.style.display = 'block';
           pollPaymentRequest();
@@ -376,6 +389,25 @@
       btnAccept.disabled = false;
       btnReject.disabled = false;
     }
+
+    btnHandshake.addEventListener('click', async function () {
+      const url = handshakeUrl.value.trim();
+      if (!url) { handshakeStatus.textContent = 'Paste a handshake URL first.'; return; }
+      btnHandshake.disabled = true;
+      handshakeStatus.textContent = 'Approving…';
+      try {
+        await json('/api/handshake', { method: 'POST', body: JSON.stringify({ url }) });
+        handshakeStatus.textContent = '✓ Login approved.';
+        handshakeStatus.style.color = 'var(--success)';
+        handshakeUrl.value = '';
+        log('Handshake approved.');
+      } catch (e) {
+        handshakeStatus.textContent = 'Error: ' + e.message;
+        handshakeStatus.style.color = 'var(--danger)';
+        log('Handshake error: ' + e.message);
+      }
+      btnHandshake.disabled = false;
+    });
 
     refreshStatus();
   </script>

--- a/crates/portal-app-demo/src/main.rs
+++ b/crates/portal-app-demo/src/main.rs
@@ -13,9 +13,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use app::{
+    parse_key_handshake_url,
     CallbackError, IncomingPaymentRequest, Mnemonic, Nsec, PortalApp, RelayStatus, RelayStatusListener,
     RelayUrl, SinglePaymentRequest,
 };
+use portal::protocol::model::auth::AuthResponseStatus;
 use app::nwc::MakeInvoiceResponse;
 use axum::{
     extract::State,
@@ -231,6 +233,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/invoice-request/reply", post(api_invoice_request_reply))
         .route("/api/invoice-request/reject", post(api_invoice_request_reject))
         .route("/api/invoice-requests/recent", get(api_invoice_requests_recent))
+        .route("/api/handshake", post(api_handshake))
         .layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any))
         .with_state(state);
 
@@ -660,4 +663,56 @@ async fn api_invoice_requests_recent(
 ) -> Json<Vec<InvoiceRequestLogEntry>> {
     let recent = state.recent_invoice_requests.read().await.clone();
     Json(recent)
+}
+
+#[derive(serde::Deserialize)]
+struct HandshakeBody {
+    url: String,
+}
+
+async fn api_handshake(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<HandshakeBody>,
+) -> Result<StatusCode, ApiError> {
+    let app = {
+        let guard = state.app.read().await;
+        guard.as_ref().ok_or_else(|| Err::internal("App not initialized"))?.clone()
+    };
+
+    let url = parse_key_handshake_url(&body.url)
+        .map_err(|e| Err::bad_request(format!("Invalid handshake URL: {}", e)))?;
+
+    // Step 1: send our pubkey to the platform.
+    app.send_key_handshake(url).await
+        .map_err(|e| Err::internal(format!("Handshake send failed: {}", e)))?;
+
+    // Step 2: wait for the auth challenge the platform sends back (up to 15s).
+    let challenge = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        app.next_auth_challenge(),
+    )
+    .await
+    .map_err(|_| Err::internal("Timed out waiting for auth challenge from platform"))?
+    .map_err(|e| Err::internal(format!("Auth challenge error: {}", e)))?;
+
+    // Step 3: approve the login.
+    let session_token = format!(
+        "demo-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    );
+    app.reply_auth_challenge(
+        challenge,
+        AuthResponseStatus::Approved {
+            granted_permissions: vec![],
+            session_token,
+        },
+    )
+    .await
+    .map_err(|e| Err::internal(format!("Auth reply failed: {}", e)))?;
+
+    log::info!("Key handshake approved.");
+    Ok(StatusCode::NO_CONTENT)
 }


### PR DESCRIPTION
## What

Adds an **Approve login** section to the portal-app-demo web UI, so you can paste a `KeyHandshakeUrl` string and approve a login from a platform (e.g. portal-demo). This lets you test the full payment flow end-to-end without the mobile app.

## Changes

**`crates/portal-app-demo/src/main.rs`**
- Import `parse_key_handshake_url` from the `app` crate
- New route: `POST /api/handshake`
- Handler: parses the URL, calls `app.send_key_handshake()`, returns 204 or error

**`crates/portal-app-demo/src/index.html`**
- New section visible once the wallet is ready
- Textarea to paste the handshake URL
- Approve button with inline success/error feedback

## Flow
1. portal-demo generates a `KeyHandshakeUrl` for a new session
2. Paste it into portal-app-demo → click Approve
3. portal-app-demo is now the receiver for that session
4. Send payments from portal-demo → portal-app-demo receives and auto-accepts them