### PR TITLE
refactor(portal-app-demo): multi-user session pool with actor model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,6 +3855,7 @@ dependencies = [
  "config",
  "dirs",
  "env_logger",
+ "futures",
  "log",
  "portal",
  "portal-wallet",
@@ -3862,6 +3863,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tower-http 0.4.4",
 ]
 
@@ -5369,6 +5371,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1.88"
 async-utility = "0.3.1"
 futures = "0.3.31"
 tokio = { version = "1.36", features = ["full", "test-util"] }
-tokio-stream = "0.1.17"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 
 # -----------------------------------------------------------------------------
 # Crypto / keys

--- a/crates/portal-app-demo/Cargo.toml
+++ b/crates/portal-app-demo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "portal-app-demo"
 version = "0.1.0"
 edition = "2024"
-description = "Minimal demo app for protocol testing: set wallet, receive one payment request, accept or reject (uses portal-app)"
+description = "Multi-session demo app for protocol testing with actor-based session pool"
 
 [[bin]]
 name = "portal-app-demo"
@@ -16,6 +16,7 @@ portal = { path = "../portal", features = ["bindings"] }
 axum = { workspace = true }
 tower-http = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
@@ -25,3 +26,4 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 config = { workspace = true }
 dirs = { workspace = true }
+futures = { workspace = true }

--- a/crates/portal-app-demo/example.config.toml
+++ b/crates/portal-app-demo/example.config.toml
@@ -1,26 +1,12 @@
 ## Config for portal-app-demo. Copy to ~/.portal-app-demo/config.toml
 ## Override via env: PORTAL_APP_DEMO__<SECTION>__<KEY>=value (double underscores)
-## Example: PORTAL_APP_DEMO__INFO__LISTEN_PORT=3030
 
 [info]
 listen_port = 3030
 
-[identity]
-## Identity: either mnemonic (12 words) or nsec. Used for Portal app (relays, payment requests).
-mnemonic = "word1 word2 ... word12"
-# nsec = "nsec1..."
-
 [nostr]
-relays = ["wss://relay.nostr.net", "wss://relay.getportal.cc"]
+default_relays = ["wss://relay.damus.io", "wss://relay.nostr.band"]
 
-[wallet]
-## Payment wallet when accepting: "none", "nwc", or "breez"
-ln_backend = "none"
-
-# [wallet.nwc]
-# url = "nostr+walletconnect://..."
-
-## Breez: data is stored under ~/.portal-app-demo/breez (single session)
-# [wallet.breez]
-# api_key = "your-breez-api-key"
-# mnemonic = "your-breez-mnemonic"
+[session]
+max_sessions = 50
+ttl_secs = 7200

--- a/crates/portal-app-demo/src/config.rs
+++ b/crates/portal-app-demo/src/config.rs
@@ -1,18 +1,16 @@
-//! Config loaded from ~/.portal-app-demo/config.toml. Breez data under ~/.portal-app-demo/breez.
+//! Config loaded from ~/.portal-app-demo/config.toml.
 
 use config::{Config, Environment, File};
-use portal_wallet::{BreezSparkWallet, NwcWallet, PortalWallet};
 use serde::Deserialize;
-use std::sync::Arc;
 
 use crate::constants;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Settings {
     pub info: InfoSettings,
-    pub identity: IdentitySettings,
     pub nostr: NostrSettings,
-    pub wallet: WalletSettings,
+    #[serde(default)]
+    pub session: SessionSettings,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -26,54 +24,41 @@ fn default_listen_port() -> u16 {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct IdentitySettings {
-    #[serde(default)]
-    pub mnemonic: Option<String>,
-    #[serde(default)]
-    pub nsec: Option<String>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
 pub struct NostrSettings {
     #[serde(default = "default_relays")]
-    pub relays: Vec<String>,
+    pub default_relays: Vec<String>,
 }
 
 fn default_relays() -> Vec<String> {
     vec![
-        "wss://relay.nostr.net".into(),
-        "wss://relay.getportal.cc".into(),
+        "wss://relay.damus.io".into(),
+        "wss://relay.nostr.band".into(),
     ]
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct WalletSettings {
-    #[serde(default)]
-    pub ln_backend: LnBackend,
-    #[serde(default)]
-    pub nwc: Option<NwcSettings>,
-    #[serde(default)]
-    pub breez: Option<BreezSettings>,
+pub struct SessionSettings {
+    #[serde(default = "default_max_sessions")]
+    pub max_sessions: usize,
+    #[serde(default = "default_ttl_secs")]
+    pub ttl_secs: u64,
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum LnBackend {
-    #[default]
-    None,
-    Nwc,
-    Breez,
+impl Default for SessionSettings {
+    fn default() -> Self {
+        Self {
+            max_sessions: default_max_sessions(),
+            ttl_secs: default_ttl_secs(),
+        }
+    }
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct NwcSettings {
-    pub url: String,
+fn default_max_sessions() -> usize {
+    50
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct BreezSettings {
-    pub api_key: String,
-    pub mnemonic: String,
+fn default_ttl_secs() -> u64 {
+    7200
 }
 
 impl Settings {
@@ -85,7 +70,7 @@ impl Settings {
             std::fs::create_dir_all(&config_dir)?;
             std::fs::write(&config_file, include_str!("../example.config.toml"))?;
             anyhow::bail!(
-                "Created config at {}. Edit it (identity + optional wallet) and restart.",
+                "Created config at {}. Edit it and restart.",
                 config_file.display()
             );
         }
@@ -97,71 +82,12 @@ impl Settings {
                     .prefix_separator("__")
                     .separator("__")
                     .list_separator(",")
-                    .with_list_parse_key("nostr.relays")
+                    .with_list_parse_key("nostr.default_relays")
                     .try_parsing(true),
             )
             .build()?
             .try_deserialize()?;
 
         Ok(settings)
-    }
-
-    pub fn validate(&self) -> anyhow::Result<()> {
-        let has_identity = self.identity.mnemonic.as_ref().map(|s| !s.is_empty()).unwrap_or(false)
-            || self.identity.nsec.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
-        if !has_identity {
-            anyhow::bail!("Set identity.mnemonic or identity.nsec in config");
-        }
-        match self.wallet.ln_backend {
-            LnBackend::None => {}
-            LnBackend::Nwc => {
-                if self.wallet.nwc.as_ref().map(|n| n.url.is_empty()).unwrap_or(true) {
-                    anyhow::bail!("wallet.ln_backend is nwc but wallet.nwc.url is not set");
-                }
-            }
-            LnBackend::Breez => {
-                if self.wallet.breez.is_none() {
-                    anyhow::bail!("wallet.ln_backend is breez but [wallet.breez] is not set");
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Build payment wallet from config. Breez storage is always ~/.portal-app-demo/breez.
-    pub async fn build_payment_wallet(&self) -> anyhow::Result<Option<Arc<dyn PortalWallet>>> {
-        match self.wallet.ln_backend {
-            LnBackend::None => Ok(None),
-            LnBackend::Nwc => {
-                let nwc = self
-                    .wallet
-                    .nwc
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("wallet.nwc not set"))?;
-                let w = NwcWallet::new(nwc.url.clone())?;
-                log::info!("Payment wallet: NWC");
-                Ok(Some(Arc::new(w)))
-            }
-            LnBackend::Breez => {
-                let b = self
-                    .wallet
-                    .breez
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("wallet.breez not set"))?;
-                let storage_dir = constants::breez_storage_dir()?
-                    .to_str()
-                    .ok_or_else(|| anyhow::anyhow!("Invalid Breez storage path"))?
-                    .to_string();
-                std::fs::create_dir_all(&storage_dir)?;
-                let w = BreezSparkWallet::new(
-                    b.api_key.clone(),
-                    storage_dir,
-                    b.mnemonic.clone(),
-                )
-                .await?;
-                log::info!("Payment wallet: Breez (storage: ~/.portal-app-demo/breez)");
-                Ok(Some(Arc::new(w)))
-            }
-        }
     }
 }

--- a/crates/portal-app-demo/src/error.rs
+++ b/crates/portal-app-demo/src/error.rs
@@ -8,7 +8,6 @@ use axum::{
 use serde::Serialize;
 use thiserror::Error;
 
-/// API error returned to the client.
 #[derive(Debug, Error)]
 pub enum ApiError {
     #[error("Bad request: {0}")]
@@ -16,6 +15,9 @@ pub enum ApiError {
 
     #[error("Not found: {0}")]
     NotFound(String),
+
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
 
     #[error("Internal error: {0}")]
     Internal(String),
@@ -30,6 +32,10 @@ impl ApiError {
         Self::NotFound(msg.into())
     }
 
+    pub fn too_many_requests(msg: impl Into<String>) -> Self {
+        Self::TooManyRequests(msg.into())
+    }
+
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
     }
@@ -38,6 +44,7 @@ impl ApiError {
         match self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::TooManyRequests(_) => StatusCode::TOO_MANY_REQUESTS,
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/crates/portal-app-demo/src/index.html
+++ b/crates/portal-app-demo/src/index.html
@@ -3,413 +3,410 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Portal App Demo — Protocol testing wallet</title>
+  <title>Portal App Demo</title>
   <style>
     :root {
-      --bg: #0f0f12;
-      --surface: #1a1a1f;
-      --border: #2a2a32;
-      --text: #e8e8ed;
-      --muted: #8888a0;
-      --accent: #6366f1;
-      --accent-hover: #818cf8;
-      --success: #22c55e;
-      --danger: #ef4444;
+      --bg: #0f0f12; --surface: #1a1a1f; --border: #2a2a32;
+      --text: #e8e8ed; --muted: #8888a0; --accent: #6366f1;
+      --accent-hover: #818cf8; --success: #22c55e; --danger: #ef4444;
     }
     * { box-sizing: border-box; }
-    body {
-      font-family: 'Segoe UI', system-ui, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      margin: 0;
-      min-height: 100vh;
-      padding: 2rem;
-      line-height: 1.5;
-    }
-    .container { max-width: 480px; margin: 0 auto; }
-    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+    body { font-family: 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); margin: 0; min-height: 100vh; padding: 2rem; line-height: 1.5; }
+    .container { max-width: 520px; margin: 0 auto; }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.25rem; }
+    h2 { font-size: 1rem; margin: 0 0 0.75rem; }
     .sub { color: var(--muted); font-size: 0.875rem; margin-bottom: 1.5rem; }
-    section {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 1.25rem;
-      margin-bottom: 1rem;
-    }
+    section { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem; margin-bottom: 1rem; }
     label { display: block; font-size: 0.8125rem; color: var(--muted); margin-bottom: 0.35rem; }
-    input, textarea, button {
-      width: 100%;
-      padding: 0.6rem 0.75rem;
-      border-radius: 8px;
-      border: 1px solid var(--border);
-      background: var(--bg);
-      color: var(--text);
-      font-size: 0.9375rem;
-    }
-    textarea { min-height: 80px; resize: vertical; }
-    button {
-      cursor: pointer;
-      font-weight: 500;
-      border: none;
-      background: var(--accent);
-      color: white;
-      margin-top: 0.75rem;
-    }
+    input, textarea, select { width: 100%; padding: 0.6rem 0.75rem; border-radius: 8px; border: 1px solid var(--border); background: var(--bg); color: var(--text); font-size: 0.875rem; margin-bottom: 0.5rem; }
+    textarea { min-height: 60px; resize: vertical; }
+    button { cursor: pointer; font-weight: 500; border: none; background: var(--accent); color: white; padding: 0.6rem 1rem; border-radius: 8px; font-size: 0.875rem; }
     button:hover { background: var(--accent-hover); }
     button:disabled { opacity: 0.5; cursor: not-allowed; }
     button.danger { background: var(--danger); }
     button.danger:hover { background: #dc2626; }
+    button.small { padding: 0.3rem 0.6rem; font-size: 0.75rem; }
+    .warn { background: #44300a; border: 1px solid #665520; color: #fbbf24; padding: 0.6rem 0.75rem; border-radius: 8px; font-size: 0.8rem; margin-bottom: 1rem; }
+    .mono { font-family: ui-monospace, monospace; font-size: 0.8rem; word-break: break-all; }
     .status { font-size: 0.8125rem; color: var(--muted); margin-top: 0.5rem; }
-    .status.ready { color: var(--success); }
-    .pubkey { word-break: break-all; font-family: ui-monospace, monospace; font-size: 0.8125rem; }
-    .payment-card {
-      background: var(--bg);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 1rem;
-      margin: 0.75rem 0;
-    }
-    .payment-card dt { color: var(--muted); font-size: 0.75rem; margin-top: 0.5rem; }
-    .payment-card dd { margin: 0.15rem 0 0; font-size: 0.875rem; }
-    .invoice-row { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 0.4rem 0.6rem; margin: 0.35rem 0; min-height: auto; }
-    .invoice-row dl { display: grid; grid-template-columns: auto 1fr; gap: 0.2rem 0.75rem; font-size: 0.75rem; margin: 0; }
+    .relay-list { list-style: none; padding: 0; margin: 0 0 0.5rem; }
+    .relay-list li { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem; }
+    .relay-list li input { flex: 1; margin: 0; }
+    .relay-list li button { padding: 0.2rem 0.5rem; font-size: 0.75rem; background: var(--danger); }
+    .payment-card { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; margin: 0.75rem 0; }
+    .payment-card dl { display: grid; grid-template-columns: auto 1fr; gap: 0.2rem 0.75rem; margin: 0; font-size: 0.8rem; }
+    .payment-card dt { color: var(--muted); }
+    .payment-card dd { margin: 0; word-break: break-all; }
+    .actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+    .actions button { flex: 1; }
+    .invoice-row { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 0.4rem 0.6rem; margin: 0.35rem 0; }
+    .invoice-row dl { display: grid; grid-template-columns: auto 1fr; gap: 0.15rem 0.6rem; font-size: 0.75rem; margin: 0; }
     .invoice-row dt { color: var(--muted); margin: 0; }
     .invoice-row dd { margin: 0; word-break: break-all; }
-    .invoice-row .invoice-ln { font-family: ui-monospace, monospace; font-size: 0.7rem; color: var(--muted); max-height: 2.2em; overflow: hidden; text-overflow: ellipsis; grid-column: 1 / -1; }
-    .actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
-    .actions button { flex: 1; margin-top: 0; }
-    #log { font-size: 0.75rem; color: var(--muted); max-height: 120px; overflow-y: auto; margin-top: 1rem; }
+    .copy-btn { cursor: pointer; background: none; border: none; color: var(--accent); font-size: 0.75rem; padding: 0; margin-left: 0.3rem; }
+    .radio-group { display: flex; gap: 1rem; margin-bottom: 0.5rem; }
+    .radio-group label { display: flex; align-items: center; gap: 0.3rem; color: var(--text); cursor: pointer; }
+    #log { font-size: 0.75rem; color: var(--muted); max-height: 120px; overflow-y: auto; margin-top: 1rem; white-space: pre-wrap; }
+    .hidden { display: none !important; }
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Portal App Demo</h1>
-    <p class="sub">Single instance from config. Receive one payment request, accept or reject.</p>
+<div class="container">
+  <h1>Portal App Demo</h1>
+  <p class="sub">Multi-session protocol testing wallet</p>
 
-    <section id="wallet-section">
-      <p id="config-path" class="status pubkey" style="margin-bottom:0.5rem;"></p>
-      <p id="wallet-status" class="status"></p>
-      <div id="wallet-pubkey-wrap" style="display:none;">
-        <p class="status" style="margin-bottom:0.25rem;">npub</p>
-        <p id="wallet-pubkey" class="pubkey status"></p>
-        <p class="status" style="margin:0.5rem 0 0.25rem;">hex</p>
-        <p id="wallet-pubkey-hex" class="pubkey status"></p>
-        <p id="wallet-payment-mode" class="status" style="margin-top:0.5rem;"></p>
-        <p id="wallet-balance" class="status" style="margin-top:0.5rem;"></p>
+  <!-- WIZARD -->
+  <div id="wizard">
+    <div class="warn">⚠️ Testing tool — do not use your main Portal key</div>
+    <section>
+      <h2>Identity</h2>
+      <div class="radio-group">
+        <label><input type="radio" name="key-mode" value="generate" checked> Generate new key</label>
+        <label><input type="radio" name="key-mode" value="nsec"> Import nsec</label>
+        <label><input type="radio" name="key-mode" value="mnemonic"> Import mnemonic</label>
+      </div>
+      <div id="nsec-input" class="hidden">
+        <label for="nsec">nsec</label>
+        <input type="text" id="nsec" placeholder="nsec1...">
+      </div>
+      <div id="mnemonic-input" class="hidden">
+        <label for="mnemonic">Mnemonic (12 words)</label>
+        <textarea id="mnemonic" placeholder="word1 word2 ... word12"></textarea>
       </div>
     </section>
 
-    <section id="handshake-section" style="display:none;">
-      <h2 style="font-size:1rem; margin:0 0 0.75rem;">Approve login</h2>
-      <label for="handshake-url">Key handshake URL</label>
-      <textarea id="handshake-url" placeholder="portal-handshake://..."></textarea>
-      <button type="button" id="btn-handshake">Approve</button>
-      <p id="handshake-status" class="status" style="margin-top:0.5rem;"></p>
+    <section>
+      <h2>Relays</h2>
+      <ul class="relay-list" id="relay-list"></ul>
+      <button type="button" class="small" id="btn-add-relay">+ Add relay</button>
     </section>
 
-    <section id="payment-section" style="display:none;">
-      <h2 style="font-size:1rem; margin:0 0 0.5rem;">Payment request</h2>
-      <p class="status">Waiting for a single payment request…</p>
+    <section>
+      <h2>Lightning Wallet (optional)</h2>
+      <label for="nwc">NWC connection string — leave empty for demo mode</label>
+      <input type="text" id="nwc" placeholder="nostr+walletconnect://...">
+    </section>
+
+    <button type="button" id="btn-continue" style="width:100%;">Continue</button>
+    <p id="wizard-error" class="status" style="color:var(--danger);"></p>
+  </div>
+
+  <!-- DASHBOARD -->
+  <div id="dashboard" class="hidden">
+    <section>
+      <h2>Session</h2>
+      <label>npub</label>
+      <p class="mono" id="d-npub"></p>
+      <label>hex</label>
+      <p class="mono" id="d-hex"></p>
+      <button type="button" class="small danger" id="btn-reset">Reset identity</button>
+    </section>
+
+    <section>
+      <h2>Approve login</h2>
+      <textarea id="handshake-url" placeholder="portal-handshake://..."></textarea>
+      <button type="button" id="btn-handshake">Approve</button>
+      <p id="handshake-status" class="status"></p>
+    </section>
+
+    <section>
+      <h2>Payment request</h2>
+      <p class="status" id="payment-waiting">Waiting for payment request…</p>
       <div id="payment-details"></div>
-      <div id="payment-actions" class="actions" style="display:none;">
+      <div id="payment-actions" class="actions hidden">
         <button type="button" id="btn-accept">Accept</button>
         <button type="button" id="btn-reject" class="danger">Reject</button>
       </div>
     </section>
 
-    <section id="invoice-request-section" style="display:none;">
-      <h2 style="font-size:1rem; margin:0 0 0.5rem;">Invoice requests (requestInvoice)</h2>
-      <p class="status">Invoice requests are auto-accepted when a wallet is configured. If one is pending (auto-accept failed), use Accept below.</p>
-      <div id="invoice-request-pending" style="display:none;">
-        <div class="payment-card" id="invoice-request-pending-card"></div>
-        <div class="actions" style="margin-top:0.5rem;">
-          <button type="button" id="btn-invoice-accept">Accept</button>
-          <button type="button" id="btn-invoice-reject" class="danger" title="No reply is sent — the requester will time out waiting for an invoice.">Reject</button>
+    <section>
+      <h2>Invoice requests</h2>
+      <div id="invoice-pending" class="hidden">
+        <div class="payment-card" id="invoice-pending-card"></div>
+        <div class="actions">
+          <button type="button" id="btn-inv-accept">Accept</button>
+          <button type="button" id="btn-inv-reject" class="danger">Reject</button>
         </div>
-        <p class="status" style="margin-top:0.35rem; font-size:0.7rem;">⚠️ Reject sends no reply — the requester will time out.</p>
       </div>
-      <div id="invoice-request-recent"></div>
+      <div id="invoice-recent"></div>
     </section>
 
     <div id="log"></div>
   </div>
+</div>
 
-  <script>
-    const API = '';
-    function log(msg) {
-      const el = document.getElementById('log');
-      if (el) el.textContent = (el.textContent ? el.textContent + '\n' : '') + new Date().toISOString().slice(11, 19) + ' ' + msg;
+<script type="module">
+import { generateSecretKey, getPublicKey, nsecEncode } from 'https://esm.sh/nostr-tools@2'
+
+const $ = s => document.querySelector(s)
+const $$ = s => document.querySelectorAll(s)
+function log(msg) {
+  const el = $('#log')
+  if (el) el.textContent = (el.textContent ? el.textContent + '\n' : '') + new Date().toISOString().slice(11,19) + ' ' + msg
+}
+function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML }
+
+// --- Relay list management ---
+let relays = []
+async function loadDefaultRelays() {
+  try {
+    const r = await fetch('/api/config')
+    const c = await r.json()
+    relays = c.default_relays || ['wss://relay.damus.io', 'wss://relay.nostr.band']
+  } catch { relays = ['wss://relay.damus.io', 'wss://relay.nostr.band'] }
+  renderRelays()
+}
+function renderRelays() {
+  const ul = $('#relay-list')
+  ul.innerHTML = relays.map((r, i) => `<li><input value="${esc(r)}" data-i="${i}"><button type="button" data-rm="${i}">×</button></li>`).join('')
+  ul.querySelectorAll('input').forEach(inp => inp.addEventListener('change', () => { relays[+inp.dataset.i] = inp.value.trim() }))
+  ul.querySelectorAll('button').forEach(btn => btn.addEventListener('click', () => { relays.splice(+btn.dataset.rm, 1); renderRelays() }))
+}
+$('#btn-add-relay').addEventListener('click', () => { relays.push('wss://'); renderRelays() })
+
+// --- Key mode toggle ---
+$$('input[name="key-mode"]').forEach(r => r.addEventListener('change', () => {
+  $('#nsec-input').classList.toggle('hidden', r.value !== 'nsec' || !r.checked)
+  $('#mnemonic-input').classList.toggle('hidden', r.value !== 'mnemonic' || !r.checked)
+}))
+
+// --- Continue ---
+$('#btn-continue').addEventListener('click', async () => {
+  const mode = document.querySelector('input[name="key-mode"]:checked').value
+  let nsec = null, mnemonic = null
+
+  if (mode === 'generate') {
+    const sk = generateSecretKey()
+    nsec = nsecEncode(sk)
+  } else if (mode === 'nsec') {
+    nsec = $('#nsec').value.trim()
+    if (!nsec) { $('#wizard-error').textContent = 'Enter an nsec'; return }
+  } else {
+    mnemonic = $('#mnemonic').value.trim()
+    if (!mnemonic) { $('#wizard-error').textContent = 'Enter a mnemonic'; return }
+  }
+
+  const validRelays = relays.filter(r => r.startsWith('wss://') || r.startsWith('ws://'))
+  if (validRelays.length === 0) { $('#wizard-error').textContent = 'Add at least one relay'; return }
+
+  const nwc = $('#nwc').value.trim() || null
+
+  $('#btn-continue').disabled = true
+  $('#wizard-error').textContent = 'Creating session…'
+  try {
+    const body = { nsec, mnemonic, relays: validRelays, nwc }
+    const resp = await fetch('/api/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    const text = await resp.text()
+    if (!resp.ok) {
+      let msg = text
+      try { const o = JSON.parse(text); if (o.error) msg = o.error } catch {}
+      throw new Error(msg)
     }
-    async function json(path, opts = {}) {
-      const r = await fetch(API + path, { headers: { 'Content-Type': 'application/json' }, ...opts });
-      const text = await r.text();
-      if (!r.ok) {
-        let msg = text;
-        try { const o = JSON.parse(text); if (o.error) msg = o.error; } catch (_) {}
-        throw new Error(msg || r.statusText);
+    const data = JSON.parse(text)
+    localStorage.setItem('portal-nsec', nsec || '')
+    localStorage.setItem('portal-mnemonic', mnemonic || '')
+    localStorage.setItem('portal-relays', JSON.stringify(validRelays))
+    if (nwc) localStorage.setItem('portal-nwc', nwc); else localStorage.removeItem('portal-nwc')
+    localStorage.setItem('portal-pubkey', data.pubkey_hex)
+    localStorage.setItem('portal-npub', data.pubkey)
+    showDashboard(data.pubkey, data.pubkey_hex)
+  } catch (e) {
+    $('#wizard-error').textContent = 'Error: ' + e.message
+  }
+  $('#btn-continue').disabled = false
+})
+
+// --- Dashboard ---
+let eventSource = null
+let pingInterval = null
+
+function showDashboard(npub, hex) {
+  $('#wizard').classList.add('hidden')
+  $('#dashboard').classList.remove('hidden')
+  $('#d-npub').textContent = npub
+  $('#d-hex').textContent = hex
+  openSse(hex)
+  pingInterval = setInterval(() => fetch(`/api/session/ping/${hex}`, { method: 'POST' }), 60000)
+}
+
+function openSse(hex) {
+  if (eventSource) eventSource.close()
+  eventSource = new EventSource(`/api/events/${hex}`)
+  eventSource.onmessage = (e) => {
+    const evt = JSON.parse(e.data)
+    if (evt.type === 'PaymentRequest') renderPayment(evt)
+    else if (evt.type === 'InvoiceRequest') renderInvoicePending(evt)
+    else if (evt.type === 'InvoiceResult') addRecentInvoice(evt)
+    else if (evt.type === 'Error') log('Error: ' + evt.message)
+  }
+  eventSource.onerror = () => { eventSource.close(); setTimeout(() => openSse(hex), 3000) }
+}
+
+// --- Payment ---
+function renderPayment(pr) {
+  $('#payment-waiting').classList.add('hidden')
+  const equiv = pr.is_fiat && pr.equivalent_sats != null ? `<dt>≈ sats</dt><dd>${pr.equivalent_sats.toLocaleString()}</dd>` : ''
+  $('#payment-details').innerHTML = `<div class="payment-card"><dl>
+    <dt>ID</dt><dd>${esc(pr.request_id)}</dd>
+    <dt>Amount</dt><dd>${esc(pr.amount_formatted)}</dd>${equiv}
+    <dt>Description</dt><dd>${pr.description ? esc(pr.description) : '—'}</dd>
+    <dt>Service</dt><dd class="mono">${esc(pr.service_key)}</dd>
+    <dt>Invoice</dt><dd class="mono">${esc(pr.invoice || '')}</dd>
+  </dl></div>`
+  $('#payment-actions').classList.remove('hidden')
+}
+
+$('#btn-accept').addEventListener('click', async () => {
+  const hex = localStorage.getItem('portal-pubkey')
+  try {
+    const r = await fetch(`/api/payment-request/${hex}/accept`, { method: 'POST' })
+    if (!r.ok) throw new Error(await r.text())
+    log('Payment accepted')
+    $('#payment-details').innerHTML = '<p class="status" style="color:var(--success);">Accepted ✓</p>'
+    $('#payment-actions').classList.add('hidden')
+    $('#payment-waiting').classList.remove('hidden')
+  } catch (e) { log('Accept error: ' + e.message) }
+})
+
+$('#btn-reject').addEventListener('click', async () => {
+  const hex = localStorage.getItem('portal-pubkey')
+  const reason = prompt('Reason (optional):') || null
+  try {
+    const r = await fetch(`/api/payment-request/${hex}/reject`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason })
+    })
+    if (!r.ok) throw new Error(await r.text())
+    log('Payment rejected')
+    $('#payment-details').innerHTML = ''
+    $('#payment-actions').classList.add('hidden')
+    $('#payment-waiting').classList.remove('hidden')
+  } catch (e) { log('Reject error: ' + e.message) }
+})
+
+// --- Invoice ---
+function renderInvoicePending(ir) {
+  const equiv = ir.equivalent_sats != null ? ` ≈ ${ir.equivalent_sats.toLocaleString()} sats` : ''
+  $('#invoice-pending-card').innerHTML = `<dl>
+    <dt>ID</dt><dd>${esc(ir.request_id)}</dd>
+    <dt>Amount</dt><dd>${esc(ir.amount_formatted)}${equiv}</dd>
+    <dt>Description</dt><dd>${ir.description ? esc(ir.description) : '—'}</dd>
+  </dl>`
+  $('#invoice-pending').classList.remove('hidden')
+}
+
+$('#btn-inv-accept').addEventListener('click', async () => {
+  const hex = localStorage.getItem('portal-pubkey')
+  try {
+    const r = await fetch(`/api/invoice-request/${hex}/reply`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ invoice: null })
+    })
+    if (!r.ok) throw new Error(await r.text())
+    log('Invoice accepted')
+    $('#invoice-pending').classList.add('hidden')
+  } catch (e) { log('Invoice accept error: ' + e.message) }
+})
+
+$('#btn-inv-reject').addEventListener('click', async () => {
+  const hex = localStorage.getItem('portal-pubkey')
+  try {
+    await fetch(`/api/invoice-request/${hex}/reject`, { method: 'POST' })
+    log('Invoice rejected')
+    $('#invoice-pending').classList.add('hidden')
+  } catch (e) { log('Invoice reject error: ' + e.message) }
+})
+
+function addRecentInvoice(evt) {
+  const div = $('#invoice-recent')
+  const color = evt.status === 'accepted' ? 'var(--success)' : 'var(--danger)'
+  const inv = evt.invoice ? `<dt>Invoice</dt><dd class="mono" style="font-size:0.7rem;max-height:2em;overflow:hidden;">${esc(evt.invoice)}</dd>` : ''
+  const err = evt.error ? `<dd style="color:var(--danger);font-size:0.7rem;">${esc(evt.error)}</dd>` : ''
+  div.insertAdjacentHTML('afterbegin', `<div class="invoice-row"><dl>
+    <dt>ID</dt><dd>${esc(evt.request_id)}</dd>
+    <dt>Status</dt><dd style="color:${color};">${esc(evt.status)}</dd>
+    ${inv}${err}
+  </dl></div>`)
+}
+
+// --- Handshake ---
+$('#btn-handshake').addEventListener('click', async () => {
+  const hex = localStorage.getItem('portal-pubkey')
+  const url = $('#handshake-url').value.trim()
+  if (!url) { $('#handshake-status').textContent = 'Paste a URL first'; return }
+  $('#btn-handshake').disabled = true
+  $('#handshake-status').textContent = 'Approving…'
+  try {
+    const r = await fetch(`/api/handshake/${hex}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    })
+    if (!r.ok) { const t = await r.text(); throw new Error(t) }
+    $('#handshake-status').textContent = '✓ Login approved'
+    $('#handshake-status').style.color = 'var(--success)'
+    $('#handshake-url').value = ''
+  } catch (e) {
+    $('#handshake-status').textContent = 'Error: ' + e.message
+    $('#handshake-status').style.color = 'var(--danger)'
+  }
+  $('#btn-handshake').disabled = false
+})
+
+// --- Reset ---
+$('#btn-reset').addEventListener('click', () => {
+  if (!confirm('Reset identity? This will clear your session.')) return
+  localStorage.removeItem('portal-nsec')
+  localStorage.removeItem('portal-mnemonic')
+  localStorage.removeItem('portal-relays')
+  localStorage.removeItem('portal-nwc')
+  localStorage.removeItem('portal-pubkey')
+  localStorage.removeItem('portal-npub')
+  if (eventSource) eventSource.close()
+  if (pingInterval) clearInterval(pingInterval)
+  location.reload()
+})
+
+// --- Init ---
+async function init() {
+  const savedNsec = localStorage.getItem('portal-nsec')
+  const savedMnemonic = localStorage.getItem('portal-mnemonic')
+  const savedPubkey = localStorage.getItem('portal-pubkey')
+  const savedNpub = localStorage.getItem('portal-npub')
+
+  if (savedPubkey && (savedNsec || savedMnemonic)) {
+    // Re-create session
+    const relaysJson = localStorage.getItem('portal-relays')
+    const savedRelays = relaysJson ? JSON.parse(relaysJson) : ['wss://relay.damus.io']
+    const nwc = localStorage.getItem('portal-nwc') || null
+    try {
+      const body = {
+        nsec: savedNsec || null,
+        mnemonic: savedMnemonic || null,
+        relays: savedRelays,
+        nwc
       }
-      return text === '' || r.status === 204 ? null : JSON.parse(text);
-    }
-
-    const configPathEl = document.getElementById('config-path');
-    const walletStatus = document.getElementById('wallet-status');
-    const walletPubkey = document.getElementById('wallet-pubkey');
-    const walletPubkeyHex = document.getElementById('wallet-pubkey-hex');
-    const walletPubkeyWrap = document.getElementById('wallet-pubkey-wrap');
-    const walletPaymentMode = document.getElementById('wallet-payment-mode');
-    const walletBalance = document.getElementById('wallet-balance');
-    const paymentSection = document.getElementById('payment-section');
-    const paymentDetails = document.getElementById('payment-details');
-    const paymentActions = document.getElementById('payment-actions');
-    const btnAccept = document.getElementById('btn-accept');
-    const btnReject = document.getElementById('btn-reject');
-    const handshakeSection = document.getElementById('handshake-section');
-    const handshakeUrl = document.getElementById('handshake-url');
-    const btnHandshake = document.getElementById('btn-handshake');
-    const handshakeStatus = document.getElementById('handshake-status');
-    const invoiceRequestSection = document.getElementById('invoice-request-section');
-    const invoiceRequestPending = document.getElementById('invoice-request-pending');
-    const invoiceRequestPendingCard = document.getElementById('invoice-request-pending-card');
-    const invoiceRequestRecent = document.getElementById('invoice-request-recent');
-    const btnInvoiceAccept = document.getElementById('btn-invoice-accept');
-    const btnInvoiceReject = document.getElementById('btn-invoice-reject');
-    let paymentWalletConfigured = false;
-
-    async function refreshStatus() {
-      try {
-        const st = await json('/api/status');
-        configPathEl.textContent = 'Config: ' + (st.config_path || '');
-        if (st.ready) {
-          walletStatus.textContent = 'Ready.';
-          walletStatus.classList.add('ready');
-          walletPubkey.textContent = st.pubkey || '';
-          walletPubkeyHex.textContent = st.pubkey_hex || '';
-          paymentWalletConfigured = !!st.payment_wallet_configured;
-          walletPaymentMode.textContent = st.payment_wallet_configured ? 'Payment wallet: NWC/Breez (real payments)' : 'Payment wallet: demo only (fake success on Accept)';
-          walletPaymentMode.style.color = st.payment_wallet_configured ? 'var(--success)' : 'var(--muted)';
-          if (st.payment_wallet_configured && st.balance_msat != null) {
-            walletBalance.textContent = 'Balance: ' + st.balance_msat.toLocaleString() + ' msat (' + (st.balance_msat / 1000).toLocaleString() + ' sats)';
-            walletBalance.style.display = 'block';
-          } else {
-            walletBalance.textContent = '';
-            walletBalance.style.display = 'none';
-          }
-          walletPubkeyWrap.style.display = 'block';
-          handshakeSection.style.display = 'block';
-          paymentSection.style.display = 'block';
-          invoiceRequestSection.style.display = 'block';
-          pollPaymentRequest();
-          pollInvoiceRequestPending();
-          pollRecentInvoiceRequests();
-        } else {
-          walletStatus.textContent = 'Not ready (check config).';
-          walletStatus.classList.remove('ready');
-          walletPubkeyWrap.style.display = 'none';
-        }
-      } catch (e) {
-        walletStatus.textContent = 'Error: ' + e.message;
-        log('status error: ' + e.message);
+      const resp = await fetch('/api/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+      if (resp.ok) {
+        const data = await resp.json()
+        showDashboard(data.pubkey, data.pubkey_hex)
+        return
       }
-    }
+    } catch (e) { log('Reconnect failed: ' + e.message) }
+  }
 
-    async function pollPaymentRequest() {
-      try {
-        const pr = await json('/api/payment-request');
-        if (pr) {
-          const amountLine = pr.amount_formatted || (pr.amount != null ? pr.amount + ' ' + escapeHtml(pr.currency) : escapeHtml(pr.currency));
-          const equivLine = pr.is_fiat && pr.equivalent_sats != null ? '<dt>≈ Lightning</dt><dd>' + pr.equivalent_sats.toLocaleString() + ' sats</dd>' : '';
-          const rateLine = pr.exchange_rate ? '<dt>Rate</dt><dd>' + escapeHtml(pr.exchange_rate.source) + ' (1 ' + escapeHtml(pr.currency) + ' ≈ ' + pr.exchange_rate.rate.toFixed(0) + ' sats)</dd>' : '';
-          paymentDetails.innerHTML = `
-            <div class="payment-card">
-              <dl>
-                <dt>Request ID</dt><dd>${escapeHtml(pr.request_id)}</dd>
-                <dt>Amount</dt><dd>${amountLine}</dd>
-                ${equivLine}
-                ${rateLine}
-                <dt>Description</dt><dd>${pr.description ? escapeHtml(pr.description) : '—'}</dd>
-                <dt>Service</dt><dd class="pubkey">${escapeHtml(pr.service_key)}</dd>
-                <dt>Invoice</dt><dd class="pubkey" style="word-break:break-all;">${escapeHtml(pr.invoice || '')}</dd>
-              </dl>
-            </div>
-          `;
-          paymentActions.style.display = 'flex';
-          btnAccept.onclick = accept;
-          btnReject.onclick = reject;
-          return;
-        }
-      } catch (e) {
-        log('poll error: ' + e.message);
-      }
-      setTimeout(pollPaymentRequest, 2000);
-    }
+  // Show wizard
+  await loadDefaultRelays()
+}
 
-    async function pollInvoiceRequestPending() {
-      try {
-        const ir = await json('/api/invoice-request');
-        if (ir) {
-          const amountLine = ir.amount_formatted || (ir.amount != null ? ir.amount + ' ' + escapeHtml(ir.currency) : escapeHtml(ir.currency));
-          const equivLine = ir.equivalent_sats != null ? ' ≈ ' + ir.equivalent_sats.toLocaleString() + ' sats' : '';
-          invoiceRequestPendingCard.innerHTML = `
-            <dl>
-              <dt>Request ID</dt><dd>${escapeHtml(ir.request_id)}</dd>
-              <dt>Amount</dt><dd>${amountLine}${equivLine}</dd>
-              <dt>Description</dt><dd>${ir.description ? escapeHtml(ir.description) : '—'}</dd>
-              <dt>Recipient</dt><dd class="pubkey">${escapeHtml(ir.recipient)}</dd>
-            </dl>
-          `;
-          invoiceRequestPending.style.display = 'block';
-          btnInvoiceAccept.onclick = acceptInvoiceRequest;
-          btnInvoiceReject.onclick = rejectInvoiceRequest;
-        } else {
-          invoiceRequestPending.style.display = 'none';
-        }
-      } catch (e) {
-        log('invoice-request pending poll error: ' + e.message);
-      }
-      setTimeout(pollInvoiceRequestPending, 2000);
-    }
-
-    async function acceptInvoiceRequest() {
-      if (btnInvoiceAccept) btnInvoiceAccept.disabled = true;
-      if (btnInvoiceReject) btnInvoiceReject.disabled = true;
-      try {
-        const r = await fetch(API + '/api/invoice-request/reply', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ invoice: '', payment_hash: null })
-        });
-        const text = await r.text();
-        if (!r.ok) {
-          let msg = text;
-          try { const o = JSON.parse(text); if (o.error) msg = o.error; } catch (_) {}
-          throw new Error(msg || r.statusText);
-        }
-        log('Accepted. Invoice created and replied.');
-        invoiceRequestPending.style.display = 'none';
-        pollRecentInvoiceRequests();
-      } catch (e) {
-        log('Accept error: ' + e.message);
-      }
-      if (btnInvoiceAccept) btnInvoiceAccept.disabled = false;
-      if (btnInvoiceReject) btnInvoiceReject.disabled = false;
-    }
-
-    async function rejectInvoiceRequest() {
-      if (btnInvoiceReject) btnInvoiceReject.disabled = true;
-      if (btnInvoiceAccept) btnInvoiceAccept.disabled = true;
-      try {
-        await fetch(API + '/api/invoice-request/reject', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-        log('Invoice request rejected.');
-        invoiceRequestPending.style.display = 'none';
-        pollRecentInvoiceRequests();
-      } catch (e) {
-        log('Reject error: ' + e.message);
-      }
-      if (btnInvoiceReject) btnInvoiceReject.disabled = false;
-      if (btnInvoiceAccept) btnInvoiceAccept.disabled = false;
-    }
-
-    function formatTime(secs) {
-      if (secs == null) return '—';
-      const d = new Date(secs * 1000);
-      return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-    }
-
-    async function pollRecentInvoiceRequests() {
-      try {
-        const list = await json('/api/invoice-requests/recent');
-        if (list && list.length > 0) {
-          invoiceRequestRecent.innerHTML = list.map(function (e) {
-            const equiv = e.equivalent_sats != null ? ' ≈ ' + e.equivalent_sats.toLocaleString() + ' sats' : '';
-            const err = e.error ? '<dt></dt><dd class="status" style="color:var(--danger);">' + escapeHtml(e.error) + '</dd>' : '';
-            const statusColor = e.status === 'accepted' ? 'var(--success)' : 'var(--danger)';
-            const invoiceLine = e.invoice ? '<dt>Invoice</dt><dd class="invoice-ln" title="' + escapeHtml(e.invoice) + '">' + escapeHtml(e.invoice) + '</dd>' : '';
-            return `
-              <div class="invoice-row">
-                <dl>
-                  <dt>Time</dt><dd>${formatTime(e.at_secs)}</dd>
-                  <dt>Amount</dt><dd>${escapeHtml(e.amount_formatted)}${equiv}</dd>
-                  <dt>Status</dt><dd style="color:${statusColor};">${escapeHtml(e.status)}</dd>
-                  ${e.description ? '<dt>Desc</dt><dd>' + escapeHtml(e.description) + '</dd>' : ''}
-                  ${invoiceLine}
-                  ${err}
-                </dl>
-              </div>
-            `;
-          }).join('');
-        } else {
-          invoiceRequestRecent.innerHTML = '<p class="status">No invoice requests yet. Recent auto-accepted requests will appear here.</p>';
-        }
-      } catch (e) {
-        log('invoice-requests recent error: ' + e.message);
-      }
-      setTimeout(pollRecentInvoiceRequests, 2000);
-    }
-
-    function escapeHtml(s) {
-      if (s == null) return '';
-      const div = document.createElement('div');
-      div.textContent = s;
-      return div.innerHTML;
-    }
-
-    async function accept() {
-      btnAccept.disabled = true;
-      btnReject.disabled = true;
-      try {
-        await fetch(API + '/api/payment-request/accept', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-        log('Accepted.');
-        paymentDetails.innerHTML = '<p class="status ready">Accepted. Demo sent success. Waiting for next request…</p>';
-        paymentActions.style.display = 'none';
-        setTimeout(pollPaymentRequest, 1000);
-      } catch (e) {
-        log('Accept error: ' + e.message);
-      }
-      btnAccept.disabled = false;
-      btnReject.disabled = false;
-    }
-
-    async function reject() {
-      const reason = prompt('Reject reason (optional):') || undefined;
-      btnAccept.disabled = true;
-      btnReject.disabled = true;
-      try {
-        await fetch(API + '/api/payment-request/reject', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ reason: reason || null })
-        });
-        log('Rejected.');
-        paymentDetails.innerHTML = '<p class="status">Rejected. Waiting for next request…</p>';
-        paymentActions.style.display = 'none';
-        setTimeout(pollPaymentRequest, 1000);
-      } catch (e) {
-        log('Reject error: ' + e.message);
-      }
-      btnAccept.disabled = false;
-      btnReject.disabled = false;
-    }
-
-    btnHandshake.addEventListener('click', async function () {
-      const url = handshakeUrl.value.trim();
-      if (!url) { handshakeStatus.textContent = 'Paste a handshake URL first.'; return; }
-      btnHandshake.disabled = true;
-      handshakeStatus.textContent = 'Approving…';
-      try {
-        await json('/api/handshake', { method: 'POST', body: JSON.stringify({ url }) });
-        handshakeStatus.textContent = '✓ Login approved.';
-        handshakeStatus.style.color = 'var(--success)';
-        handshakeUrl.value = '';
-        log('Handshake approved.');
-      } catch (e) {
-        handshakeStatus.textContent = 'Error: ' + e.message;
-        handshakeStatus.style.color = 'var(--danger)';
-        log('Handshake error: ' + e.message);
-      }
-      btnHandshake.disabled = false;
-    });
-
-    refreshStatus();
-  </script>
+init()
+</script>
 </body>
 </html>

--- a/crates/portal-app-demo/src/main.rs
+++ b/crates/portal-app-demo/src/main.rs
@@ -1,7 +1,7 @@
-//! portal-app-demo: minimal demo for protocol testing.
+//! portal-app-demo: multi-session demo for protocol testing.
 //!
-//! Single app instance from config at ~/.portal-app-demo/config.toml.
-//! Breez data is stored under ~/.portal-app-demo/breez.
+//! Sessions are created via POST /api/session with key material.
+//! Each session runs an actor task that handles payment/invoice requests.
 //!
 //! Usage: `cargo run -p portal-app-demo` then open http://127.0.0.1:3030
 
@@ -9,104 +9,120 @@ mod config;
 mod constants;
 mod error;
 
+use std::collections::HashMap;
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use app::{
-    parse_key_handshake_url,
-    CallbackError, IncomingPaymentRequest, Mnemonic, Nsec, PortalApp, RelayStatus, RelayStatusListener,
-    RelayUrl, SinglePaymentRequest,
+    parse_key_handshake_url, CallbackError, IncomingPaymentRequest, Mnemonic, Nsec, PortalApp,
+    RelayStatus, RelayStatusListener, RelayUrl, SinglePaymentRequest,
 };
-use portal::protocol::model::auth::AuthResponseStatus;
 use app::nwc::MakeInvoiceResponse;
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::StatusCode,
-    response::Html,
+    response::{Html, sse::{Event, KeepAlive, Sse}},
     routing::{get, post},
     Json, Router,
 };
 use error::ApiError;
-use error::ApiError as Err;
+use futures::StreamExt;
+use portal::protocol::model::auth::AuthResponseStatus;
+use portal::protocol::model::bindings::PublicKey;
 use portal::protocol::model::payment::{
     Currency, ExchangeRate, InvoiceRequestContentWithKey, PaymentResponseContent, PaymentStatus,
 };
-use portal_wallet::PortalWallet;
+use portal_wallet::{NwcWallet, PortalWallet};
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use tokio::time::Instant;
+use tokio_stream::wrappers::BroadcastStream;
 use tower_http::cors::{Any, CorsLayer};
 
-// -----------------------------------------------------------------------------
-// State
-// -----------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// AppConfig
+// ---------------------------------------------------------------------------
 
-/// One entry in the recent invoice-requests log (auto-accepted).
-#[derive(Clone, Serialize)]
-struct InvoiceRequestLogEntry {
-    request_id: String,
-    amount_formatted: String,
-    currency: String,
-    is_fiat: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    equivalent_sats: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    at_secs: u64,
-    status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-    /// Bolt11 invoice (ln...) when status is accepted.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    invoice: Option<String>,
+#[derive(Clone)]
+struct AppConfig {
+    listen_port: u16,
+    default_relays: Vec<String>,
+    max_sessions: usize,
+    session_ttl_secs: u64,
 }
 
-const MAX_RECENT_INVOICE_REQUESTS: usize = 100;
+// ---------------------------------------------------------------------------
+// GlobalState
+// ---------------------------------------------------------------------------
 
-struct AppState {
-    app: RwLock<Option<Arc<PortalApp>>>,
-    pubkey: RwLock<Option<String>>,
-    pubkey_hex: RwLock<Option<String>>,
-    payment_wallet: RwLock<Option<Arc<dyn PortalWallet>>>,
-    pending_request: RwLock<Option<SinglePaymentRequest>>,
-    pending_invoice_request: RwLock<Option<InvoiceRequestContentWithKey>>,
-    recent_invoice_requests: RwLock<Vec<InvoiceRequestLogEntry>>,
-    config_path: String,
+struct GlobalState {
+    sessions: RwLock<HashMap<PublicKey, mpsc::Sender<ActorCmd>>>,
+    config: AppConfig,
 }
 
-// -----------------------------------------------------------------------------
-// Request/response types
-// -----------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Actor commands
+// ---------------------------------------------------------------------------
 
-#[derive(Serialize)]
-struct StatusResponse {
-    ready: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pubkey: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pubkey_hex: Option<String>,
+enum ActorCmd {
+    Status { reply: oneshot::Sender<StatusDto> },
+    Subscribe { reply: oneshot::Sender<broadcast::Receiver<SseEvent>> },
+    GetPayment { reply: oneshot::Sender<Option<PaymentRequestDto>> },
+    AcceptPayment { reply: oneshot::Sender<Result<(), String>> },
+    RejectPayment { reason: Option<String>, reply: oneshot::Sender<Result<(), String>> },
+    GetInvoice { reply: oneshot::Sender<Option<InvoiceRequestDto>> },
+    ReplyInvoice { invoice: Option<String>, reply: oneshot::Sender<Result<(), String>> },
+    RejectInvoice { reply: oneshot::Sender<()> },
+    RecentInvoices { reply: oneshot::Sender<Vec<InvoiceRequestLogEntry>> },
+    Handshake { url: String, reply: oneshot::Sender<Result<(), String>> },
+    Ping,
+}
+
+// ---------------------------------------------------------------------------
+// SSE events
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+#[serde(tag = "type")]
+enum SseEvent {
+    PaymentRequest(PaymentRequestDto),
+    InvoiceRequest(InvoiceRequestDto),
+    InvoiceResult {
+        request_id: String,
+        status: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        invoice: Option<String>,
+    },
+    Error { message: String },
+}
+
+// ---------------------------------------------------------------------------
+// DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+struct StatusDto {
+    pubkey: String,
+    pubkey_hex: String,
     payment_wallet_configured: bool,
-    /// Balance in msat (when payment wallet is configured).
     #[serde(skip_serializing_if = "Option::is_none")]
     balance_msat: Option<u64>,
-    /// Config file path (e.g. ~/.portal-app-demo/config.toml).
-    config_path: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct PaymentRequestDto {
     request_id: String,
     event_id: String,
-    /// Raw amount (msat for Lightning, or smallest fiat unit e.g. cents for USD).
     amount: u64,
-    /// Human-readable amount and currency, e.g. "10.50 USD" or "100,000 msat (100 sats)".
     amount_formatted: String,
-    /// True when currency is fiat (e.g. USD).
     is_fiat: bool,
     currency: String,
-    /// When fiat, optional exchange rate (rate + source) for display.
     #[serde(skip_serializing_if = "Option::is_none")]
     exchange_rate: Option<ExchangeRateDto>,
-    /// When fiat and exchange_rate present, approximate equivalent in sats (for display).
     #[serde(skip_serializing_if = "Option::is_none")]
     equivalent_sats: Option<u64>,
     description: Option<String>,
@@ -116,18 +132,13 @@ struct PaymentRequestDto {
     invoice: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct ExchangeRateDto {
     pub rate: f64,
     pub source: String,
 }
 
-#[derive(serde::Deserialize)]
-struct RejectBody {
-    reason: Option<String>,
-}
-
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct InvoiceRequestDto {
     request_id: String,
     amount: u64,
@@ -143,15 +154,62 @@ struct InvoiceRequestDto {
     expires_at_secs: u64,
 }
 
-#[derive(Deserialize)]
-struct InvoiceReplyBody {
-    invoice: String,
-    payment_hash: Option<String>,
+#[derive(Clone, Serialize)]
+struct InvoiceRequestLogEntry {
+    request_id: String,
+    amount_formatted: String,
+    currency: String,
+    is_fiat: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    equivalent_sats: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    at_secs: u64,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    invoice: Option<String>,
 }
 
-// -----------------------------------------------------------------------------
-// Relay status listener (no-op for demo)
-// -----------------------------------------------------------------------------
+const MAX_RECENT_INVOICE_REQUESTS: usize = 100;
+
+// ---------------------------------------------------------------------------
+// Request/response for POST /api/session
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct CreateSessionRequest {
+    nsec: Option<String>,
+    mnemonic: Option<String>,
+    relays: Vec<String>,
+    nwc: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateSessionResponse {
+    pubkey: String,
+    pubkey_hex: String,
+}
+
+#[derive(Deserialize)]
+struct RejectBody {
+    reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct InvoiceReplyBody {
+    invoice: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct HandshakeBody {
+    url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Relay status listener (no-op)
+// ---------------------------------------------------------------------------
 
 struct NoOpRelayStatusListener;
 
@@ -166,338 +224,28 @@ impl RelayStatusListener for NoOpRelayStatusListener {
     }
 }
 
-// -----------------------------------------------------------------------------
-// Entrypoint: load config, create single app instance
-// -----------------------------------------------------------------------------
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-
-    let settings = config::Settings::load()?;
-    settings.validate()?;
-
-    let config_path = constants::portal_app_demo_dir()?
-        .join("config.toml")
-        .display()
-        .to_string();
-    log::info!("Config: {}", config_path);
-
-    let keypair = build_keypair_from_config(&settings)?;
-    let relays = settings.nostr.relays.clone();
-    let listener = Arc::new(NoOpRelayStatusListener);
-    let app = PortalApp::new(keypair.clone(), relays, listener)
-        .await
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    let pubkey_str = portal::nostr::nips::nip19::ToBech32::to_bech32(&*keypair.public_key())
-        .unwrap_or_else(|_| app::key_to_hex(keypair.public_key()));
-    let pubkey_hex_str = app::key_to_hex(keypair.public_key());
-    let payment_wallet = settings.build_payment_wallet().await?;
-
-    let state = Arc::new(AppState {
-        app: RwLock::new(Some(Arc::clone(&app))),
-        pubkey: RwLock::new(Some(pubkey_str.clone())),
-        pubkey_hex: RwLock::new(Some(pubkey_hex_str)),
-        payment_wallet: RwLock::new(payment_wallet),
-        pending_request: RwLock::new(None),
-        pending_invoice_request: RwLock::new(None),
-        recent_invoice_requests: RwLock::new(Vec::new()),
-        config_path: config_path.clone(),
-    });
-
-    let app_listen = Arc::clone(&app);
-    tokio::spawn(async move {
-        let _ = app_listen.listen().await;
-    });
-    let state_payment = Arc::clone(&state);
-    let app_payment = Arc::clone(&app);
-    tokio::spawn(async move {
-        payment_request_loop(app_payment, state_payment).await;
-    });
-    let state_invoice = Arc::clone(&state);
-    let app_invoice = Arc::clone(&app);
-    tokio::spawn(async move {
-        invoice_request_loop(app_invoice, state_invoice).await;
-    });
-
-    log::info!("Wallet ready. Pubkey: {}", pubkey_str);
-
-    let router = Router::new()
-        .route("/", get(serve_index))
-        .route("/api/status", get(api_status))
-        .route("/api/payment-request", get(api_payment_request))
-        .route("/api/payment-request/accept", post(api_accept))
-        .route("/api/payment-request/reject", post(api_reject))
-        .route("/api/invoice-request", get(api_invoice_request))
-        .route("/api/invoice-request/reply", post(api_invoice_request_reply))
-        .route("/api/invoice-request/reject", post(api_invoice_request_reject))
-        .route("/api/invoice-requests/recent", get(api_invoice_requests_recent))
-        .route("/api/handshake", post(api_handshake))
-        .layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any))
-        .with_state(state);
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], settings.info.listen_port));
-    log::info!("portal-app-demo listening on http://{}/", addr);
-    axum::Server::bind(&addr)
-        .serve(router.into_make_service())
-        .await?;
-    Ok(())
-}
-
-fn build_keypair_from_config(settings: &config::Settings) -> anyhow::Result<Arc<app::Keypair>> {
-    if let Some(ref words) = settings.identity.mnemonic {
-        let words = words.trim();
-        if !words.is_empty() {
-            let mnemonic = Mnemonic::new(words).map_err(|e| anyhow::anyhow!("Invalid mnemonic: {:?}", e))?;
-            let kp = mnemonic.get_keypair().map_err(|e| anyhow::anyhow!("Keypair: {:?}", e))?;
-            return Ok(Arc::new(kp));
-        }
-    }
-    if let Some(ref nsec) = settings.identity.nsec {
-        let nsec = nsec.trim();
-        if !nsec.is_empty() {
-            let n = Nsec::new(nsec).map_err(|e| anyhow::anyhow!("Invalid nsec: {:?}", e))?;
-            return Ok(Arc::new(n.get_keypair()));
-        }
-    }
-    anyhow::bail!("Set identity.mnemonic or identity.nsec in config")
-}
-
-// -----------------------------------------------------------------------------
-// Handlers
-// -----------------------------------------------------------------------------
-
-async fn serve_index() -> Html<&'static str> {
-    Html(include_str!("index.html"))
-}
-
-async fn api_status(State(state): State<Arc<AppState>>) -> Json<StatusResponse> {
-    let pubkey = state.pubkey.read().await.clone();
-    let pubkey_hex = state.pubkey_hex.read().await.clone();
-    let payment_wallet = state.payment_wallet.read().await.clone();
-    let payment_wallet_configured = payment_wallet.is_some();
-    let balance_msat = match payment_wallet.as_ref() {
-        Some(w) => w.get_balance().await.ok(),
-        None => None,
-    };
-    Json(StatusResponse {
-        ready: pubkey.is_some(),
-        pubkey,
-        pubkey_hex,
-        payment_wallet_configured,
-        balance_msat,
-        config_path: state.config_path.clone(),
-    })
-}
-
-async fn payment_request_loop(app: Arc<PortalApp>, state: Arc<AppState>) {
-    loop {
-        match app.next_payment_request().await {
-            Ok(IncomingPaymentRequest::Single(request)) => {
-                log::info!("Received single payment request: {:?}", request);
-                *state.pending_request.write().await = Some(request);
-            }
-            Ok(IncomingPaymentRequest::Recurring(_)) => {
-                log::debug!("Demo ignores recurring payment requests");
-            }
-            Err(e) => {
-                log::error!("payment_request_loop error: {:?}", e);
-                break;
-            }
-        }
-    }
-}
-
-async fn invoice_request_loop(app: Arc<PortalApp>, state: Arc<AppState>) {
-    loop {
-        match app.next_invoice_request().await {
-            Ok(request) => {
-                log::info!("Received invoice request: {:?}", request);
-                // Deduplicate: router may deliver the same event to multiple subscriptions
-                {
-                    let recent = state.recent_invoice_requests.read().await;
-                    let request_id = request.inner.request_id.as_str();
-                    let now_secs = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    if recent.iter().any(|e| e.request_id == request_id && now_secs.saturating_sub(e.at_secs) < 30) {
-                        log::debug!("Skipping duplicate invoice request: {}", request_id);
-                        continue;
-                    }
-                }
-                // Store so manual Accept still works if auto-accept fails
-                *state.pending_invoice_request.write().await = Some(request.clone());
-                let dto = invoice_request_to_dto(&request);
-                let at_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-
-                let payment_wallet = state.payment_wallet.read().await.clone();
-                let amount_msat = invoice_request_amount_msat(&request);
-
-                let (status, error, invoice_opt) = match (payment_wallet.as_ref(), amount_msat) {
-                    (Some(wallet), Some(msat)) => {
-                        if msat == 0 {
-                            ("failed", Some("Amount is zero".into()), None)
-                        } else {
-                            match wallet
-                                .make_invoice(msat, request.inner.description.clone())
-                                .await
-                            {
-                                Ok(invoice) => {
-                                    if let Err(e) = app
-                                        .reply_invoice_request(
-                                            request.clone(),
-                                            MakeInvoiceResponse {
-                                                invoice: invoice.clone(),
-                                                payment_hash: None,
-                                            },
-                                        )
-                                        .await
-                                    {
-                                        log::warn!("Invoice reply failed: {}", e);
-                                        ("failed", Some(format!("Reply failed: {}", e)), None)
-                                    } else {
-                                        log::info!("Invoice request auto-accepted, invoice created");
-                                        *state.pending_invoice_request.write().await = None;
-                                        ("accepted", None, Some(invoice))
-                                    }
-                                }
-                                Err(e) => {
-                                    log::warn!("make_invoice failed: {}", e);
-                                    ("failed", Some(e.to_string()), None)
-                                }
-                            }
-                        }
-                    }
-                    (None, _) => {
-                        log::warn!("Invoice request not replied: no payment wallet configured");
-                        ("failed", Some("No payment wallet configured".into()), None)
-                    }
-                    (_, None) => {
-                        log::warn!("Invoice request not replied: fiat has no exchange rate");
-                        ("failed", Some("Fiat request has no exchange rate".into()), None)
-                    }
-                };
-
-                let entry = InvoiceRequestLogEntry {
-                    request_id: dto.request_id,
-                    amount_formatted: dto.amount_formatted,
-                    currency: dto.currency,
-                    is_fiat: dto.is_fiat,
-                    equivalent_sats: dto.equivalent_sats,
-                    description: dto.description,
-                    at_secs,
-                    status: status.to_string(),
-                    error,
-                    invoice: invoice_opt,
-                };
-                let mut recent = state.recent_invoice_requests.write().await;
-                recent.insert(0, entry);
-                if recent.len() > MAX_RECENT_INVOICE_REQUESTS {
-                    recent.truncate(MAX_RECENT_INVOICE_REQUESTS);
-                }
-            }
-            Err(e) => {
-                log::error!("invoice_request_loop error: {:?}", e);
-                break;
-            }
-        }
-    }
-}
-
-fn invoice_request_to_dto(r: &InvoiceRequestContentWithKey) -> InvoiceRequestDto {
-    let c = &r.inner;
-    let amount = c.amount;
-    let (currency, amount_formatted, is_fiat, exchange_rate, equivalent_sats) = match &c.currency {
-        Currency::Millisats => {
-            let sats = amount / 1000;
-            (
-                String::from("msat"),
-                format!("{} msat ({} sats)", amount, sats),
-                false,
-                None,
-                None,
-            )
-        }
-        Currency::Fiat(code) => {
-            let major = amount as f64 / 100.0;
-            let formatted = format!("{:.2} {}", major, code);
-            let (exchange_rate_dto, equivalent_sats) = match &c.current_exchange_rate {
-                Some(ExchangeRate { rate, source, .. }) => {
-                    // rate = fiat per BTC (same as portal_rates), so sats = (fiat_amount / rate) * 100e6
-                    let eq_sats = ((major / *rate) * 100_000_000.0) as u64;
-                    (
-                        Some(ExchangeRateDto {
-                            rate: *rate,
-                            source: source.clone(),
-                        }),
-                        Some(eq_sats),
-                    )
-                }
-                None => (None, None),
-            };
-            (code.clone(), formatted, true, exchange_rate_dto, equivalent_sats)
-        }
-    };
-    InvoiceRequestDto {
-        request_id: c.request_id.clone(),
-        amount,
-        amount_formatted,
-        is_fiat,
-        currency,
-        exchange_rate,
-        equivalent_sats,
-        description: c.description.clone(),
-        recipient: r.recipient.to_string(),
-        expires_at_secs: c.expires_at.as_u64(),
-    }
-}
-
-/// Compute amount in msat for wallet.make_invoice. Returns None if fiat and no exchange rate.
-/// For fiat, rate is "fiat per BTC" (same as portal_rates), so msat = (fiat_amount / rate) * 100e9.
-fn invoice_request_amount_msat(r: &InvoiceRequestContentWithKey) -> Option<u64> {
-    let c = &r.inner;
-    match &c.currency {
-        Currency::Millisats => Some(c.amount),
-        Currency::Fiat(_) => {
-            let major = c.amount as f64 / 100.0;
-            c.current_exchange_rate.as_ref().map(|er| ((major / er.rate) * 100_000_000_000.0) as u64)
-        }
-    }
-}
+// ---------------------------------------------------------------------------
+// DTO helpers
+// ---------------------------------------------------------------------------
 
 fn single_request_to_dto(r: &SinglePaymentRequest) -> PaymentRequestDto {
-    use portal::protocol::model::payment::{Currency, ExchangeRate};
     let amount = r.content.amount;
     let (currency, amount_formatted, is_fiat, exchange_rate, equivalent_sats) = match &r.content.currency {
         Currency::Millisats => {
             let sats = amount / 1000;
-            let formatted = format!("{} msat ({} sats)", amount, sats);
-            (String::from("msat"), formatted, false, None, None)
+            (String::from("msat"), format!("{} msat ({} sats)", amount, sats), false, None, None)
         }
         Currency::Fiat(code) => {
-            // Fiat amount is typically in smallest unit (e.g. cents for USD): 1050 = 10.50 USD
             let major = amount as f64 / 100.0;
             let formatted = format!("{:.2} {}", major, code);
-            let (exchange_rate_dto, equivalent_sats) = match &r.content.current_exchange_rate {
+            let (er, eq) = match &r.content.current_exchange_rate {
                 Some(ExchangeRate { rate, source, .. }) => {
-                    // rate = fiat per BTC (same as portal_rates), so sats = (fiat_amount / rate) * 100e6
                     let eq_sats = ((major / *rate) * 100_000_000.0) as u64;
-                    (
-                        Some(ExchangeRateDto {
-                            rate: *rate,
-                            source: source.clone(),
-                        }),
-                        Some(eq_sats),
-                    )
+                    (Some(ExchangeRateDto { rate: *rate, source: source.clone() }), Some(eq_sats))
                 }
                 None => (None, None),
             };
-            (code.clone(), formatted, true, exchange_rate_dto, equivalent_sats)
+            (code.clone(), formatted, true, er, eq)
         }
     };
     PaymentRequestDto {
@@ -517,185 +265,380 @@ fn single_request_to_dto(r: &SinglePaymentRequest) -> PaymentRequestDto {
     }
 }
 
-async fn api_payment_request(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<Option<PaymentRequestDto>>, ApiError> {
-    let guard = state.pending_request.read().await;
-    Ok(Json(guard.as_ref().map(single_request_to_dto)))
+fn invoice_request_to_dto(r: &InvoiceRequestContentWithKey) -> InvoiceRequestDto {
+    let c = &r.inner;
+    let amount = c.amount;
+    let (currency, amount_formatted, is_fiat, exchange_rate, equivalent_sats) = match &c.currency {
+        Currency::Millisats => {
+            let sats = amount / 1000;
+            (String::from("msat"), format!("{} msat ({} sats)", amount, sats), false, None, None)
+        }
+        Currency::Fiat(code) => {
+            let major = amount as f64 / 100.0;
+            let formatted = format!("{:.2} {}", major, code);
+            let (er, eq) = match &c.current_exchange_rate {
+                Some(ExchangeRate { rate, source, .. }) => {
+                    let eq_sats = ((major / *rate) * 100_000_000.0) as u64;
+                    (Some(ExchangeRateDto { rate: *rate, source: source.clone() }), Some(eq_sats))
+                }
+                None => (None, None),
+            };
+            (code.clone(), formatted, true, er, eq)
+        }
+    };
+    InvoiceRequestDto {
+        request_id: c.request_id.clone(),
+        amount,
+        amount_formatted,
+        is_fiat,
+        currency,
+        exchange_rate,
+        equivalent_sats,
+        description: c.description.clone(),
+        recipient: r.recipient.to_string(),
+        expires_at_secs: c.expires_at.as_u64(),
+    }
 }
 
-async fn api_accept(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
-    let app_guard = state.app.read().await;
-    let app = app_guard.as_ref().ok_or_else(|| Err::bad_request("App not ready"))?;
-    let request = state.pending_request.write().await.take().ok_or_else(|| Err::not_found("No pending payment request"))?;
-    let payment_wallet = state.payment_wallet.read().await.clone();
+fn invoice_request_amount_msat(r: &InvoiceRequestContentWithKey) -> Option<u64> {
+    let c = &r.inner;
+    match &c.currency {
+        Currency::Millisats => Some(c.amount),
+        Currency::Fiat(_) => {
+            let major = c.amount as f64 / 100.0;
+            c.current_exchange_rate.as_ref().map(|er| ((major / er.rate) * 100_000_000_000.0) as u64)
+        }
+    }
+}
 
-    let request_id = request.content.request_id.clone();
-    let invoice = request.content.invoice.clone();
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
 
-    let approved = PaymentResponseContent {
-        request_id: request_id.clone(),
-        status: PaymentStatus::Approved,
-    };
-    app.reply_single_payment_request(request.clone(), approved)
-        .await
-        .map_err(|e| Err::internal(e.to_string()))?;
+async fn run_actor(
+    pubkey: PublicKey,
+    mut rx: mpsc::Receiver<ActorCmd>,
+    app: Arc<PortalApp>,
+    wallet: Option<Arc<dyn PortalWallet>>,
+    global: Arc<GlobalState>,
+) {
+    let mut pending_payment: Option<SinglePaymentRequest> = None;
+    let mut pending_invoice: Option<InvoiceRequestContentWithKey> = None;
+    let mut recent_invoices: Vec<InvoiceRequestLogEntry> = vec![];
+    let (sse_tx, _) = broadcast::channel::<SseEvent>(64);
+    let ttl = Duration::from_secs(global.config.session_ttl_secs);
+    let mut deadline = Instant::now() + ttl;
 
-    let status = if let Some(pw) = payment_wallet {
-        match pw.pay_invoice(invoice).await {
-            Ok((preimage, _)) => PaymentResponseContent {
-                request_id: request_id.clone(),
-                status: PaymentStatus::Success {
-                    preimage: Some(preimage),
-                },
-            },
-            Err(e) => {
-                log::error!("Payment failed: {}", e);
-                PaymentResponseContent {
-                    request_id: request_id.clone(),
-                    status: PaymentStatus::Failed {
-                        reason: Some(e.to_string()),
-                    },
+    // Start listening on the app
+    let app_listen = Arc::clone(&app);
+    tokio::spawn(async move {
+        let _ = app_listen.listen().await;
+    });
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => {
+                log::info!("Session expired for {}", app::key_to_hex(pubkey));
+                break;
+            }
+            result = app.next_payment_request() => {
+                match result {
+                    Ok(IncomingPaymentRequest::Single(request)) => {
+                        log::info!("Payment request received");
+                        let dto = single_request_to_dto(&request);
+                        let _ = sse_tx.send(SseEvent::PaymentRequest(dto));
+                        pending_payment = Some(request);
+                    }
+                    Ok(IncomingPaymentRequest::Recurring(_)) => {
+                        log::debug!("Ignoring recurring payment request");
+                    }
+                    Err(e) => {
+                        log::error!("next_payment_request error: {:?}", e);
+                        let _ = sse_tx.send(SseEvent::Error { message: format!("Payment listener error: {}", e) });
+                        break;
+                    }
                 }
             }
+            result = app.next_invoice_request() => {
+                match result {
+                    Ok(request) => {
+                        log::info!("Invoice request received");
+                        // Deduplicate
+                        let request_id = request.inner.request_id.as_str();
+                        let now_secs = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+                        if recent_invoices.iter().any(|e| e.request_id == request_id && now_secs.saturating_sub(e.at_secs) < 30) {
+                            log::debug!("Skipping duplicate invoice request: {}", request_id);
+                            continue;
+                        }
+
+                        let dto = invoice_request_to_dto(&request);
+                        let _ = sse_tx.send(SseEvent::InvoiceRequest(dto.clone()));
+
+                        let amount_msat = invoice_request_amount_msat(&request);
+
+                        // Auto-accept if wallet is configured
+                        let (status, error, invoice_opt) = match (wallet.as_ref(), amount_msat) {
+                            (Some(w), Some(msat)) if msat > 0 => {
+                                match w.make_invoice(msat, request.inner.description.clone()).await {
+                                    Ok(invoice) => {
+                                        match app.reply_invoice_request(
+                                            request.clone(),
+                                            MakeInvoiceResponse { invoice: invoice.clone(), payment_hash: None },
+                                        ).await {
+                                            Ok(_) => {
+                                                log::info!("Invoice request auto-accepted");
+                                                ("accepted", None, Some(invoice))
+                                            }
+                                            Err(e) => {
+                                                log::warn!("Invoice reply failed: {}", e);
+                                                pending_invoice = Some(request);
+                                                ("failed", Some(format!("Reply failed: {}", e)), None)
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        log::warn!("make_invoice failed: {}", e);
+                                        pending_invoice = Some(request);
+                                        ("failed", Some(e.to_string()), None)
+                                    }
+                                }
+                            }
+                            _ => {
+                                // No wallet or zero amount or no exchange rate — store pending
+                                pending_invoice = Some(request);
+                                continue; // Don't log yet, wait for manual action
+                            }
+                        };
+
+                        let entry = InvoiceRequestLogEntry {
+                            request_id: dto.request_id.clone(),
+                            amount_formatted: dto.amount_formatted.clone(),
+                            currency: dto.currency.clone(),
+                            is_fiat: dto.is_fiat,
+                            equivalent_sats: dto.equivalent_sats,
+                            description: dto.description.clone(),
+                            at_secs: now_secs,
+                            status: status.to_string(),
+                            error: error.clone(),
+                            invoice: invoice_opt.clone(),
+                        };
+
+                        let _ = sse_tx.send(SseEvent::InvoiceResult {
+                            request_id: dto.request_id.clone(),
+                            status: status.to_string(),
+                            error,
+                            invoice: invoice_opt,
+                        });
+
+                        recent_invoices.insert(0, entry);
+                        if recent_invoices.len() > MAX_RECENT_INVOICE_REQUESTS {
+                            recent_invoices.truncate(MAX_RECENT_INVOICE_REQUESTS);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("next_invoice_request error: {:?}", e);
+                        let _ = sse_tx.send(SseEvent::Error { message: format!("Invoice listener error: {}", e) });
+                        break;
+                    }
+                }
+            }
+            Some(cmd) = rx.recv() => {
+                deadline = Instant::now() + ttl;
+                match cmd {
+                    ActorCmd::Ping => {}
+                    ActorCmd::Status { reply } => {
+                        let pubkey_bech32 = portal::nostr::nips::nip19::ToBech32::to_bech32(&*pubkey)
+                            .unwrap_or_else(|_| app::key_to_hex(pubkey));
+                        let balance = match wallet.as_ref() {
+                            Some(w) => w.get_balance().await.ok(),
+                            None => None,
+                        };
+                        let _ = reply.send(StatusDto {
+                            pubkey: pubkey_bech32,
+                            pubkey_hex: app::key_to_hex(pubkey),
+                            payment_wallet_configured: wallet.is_some(),
+                            balance_msat: balance,
+                        });
+                    }
+                    ActorCmd::Subscribe { reply } => {
+                        let _ = reply.send(sse_tx.subscribe());
+                    }
+                    ActorCmd::GetPayment { reply } => {
+                        let _ = reply.send(pending_payment.as_ref().map(single_request_to_dto));
+                    }
+                    ActorCmd::AcceptPayment { reply } => {
+                        let Some(request) = pending_payment.take() else {
+                            let _ = reply.send(Err("No pending payment request".into()));
+                            continue;
+                        };
+                        let request_id = request.content.request_id.clone();
+                        let invoice = request.content.invoice.clone();
+
+                        let approved = PaymentResponseContent {
+                            request_id: request_id.clone(),
+                            status: PaymentStatus::Approved,
+                        };
+                        if let Err(e) = app.reply_single_payment_request(request.clone(), approved).await {
+                            let _ = reply.send(Err(format!("Approve failed: {}", e)));
+                            pending_payment = Some(request);
+                            continue;
+                        }
+
+                        let final_status = if let Some(ref pw) = wallet {
+                            match pw.pay_invoice(invoice).await {
+                                Ok((preimage, _)) => PaymentResponseContent {
+                                    request_id: request_id.clone(),
+                                    status: PaymentStatus::Success { preimage: Some(preimage) },
+                                },
+                                Err(e) => {
+                                    log::error!("Payment failed: {}", e);
+                                    PaymentResponseContent {
+                                        request_id: request_id.clone(),
+                                        status: PaymentStatus::Failed { reason: Some(e.to_string()) },
+                                    }
+                                }
+                            }
+                        } else {
+                            PaymentResponseContent {
+                                request_id,
+                                status: PaymentStatus::Success {
+                                    preimage: Some("demo-preimage-for-protocol-testing".to_string()),
+                                },
+                            }
+                        };
+
+                        if let Err(e) = app.reply_single_payment_request(request, final_status).await {
+                            let _ = reply.send(Err(format!("Final reply failed: {}", e)));
+                        } else {
+                            let _ = reply.send(Ok(()));
+                        }
+                    }
+                    ActorCmd::RejectPayment { reason, reply } => {
+                        let Some(request) = pending_payment.take() else {
+                            let _ = reply.send(Err("No pending payment request".into()));
+                            continue;
+                        };
+                        let content = PaymentResponseContent {
+                            request_id: request.content.request_id.clone(),
+                            status: PaymentStatus::Rejected { reason },
+                        };
+                        match app.reply_single_payment_request(request, content).await {
+                            Ok(_) => { let _ = reply.send(Ok(())); }
+                            Err(e) => { let _ = reply.send(Err(e.to_string())); }
+                        }
+                    }
+                    ActorCmd::GetInvoice { reply } => {
+                        let _ = reply.send(pending_invoice.as_ref().map(invoice_request_to_dto));
+                    }
+                    ActorCmd::ReplyInvoice { invoice, reply } => {
+                        let Some(request) = pending_invoice.take() else {
+                            let _ = reply.send(Err("No pending invoice request".into()));
+                            continue;
+                        };
+                        let inv = match invoice {
+                            Some(inv) if !inv.trim().is_empty() => inv.trim().to_string(),
+                            _ => {
+                                // Create via wallet
+                                let Some(ref w) = wallet else {
+                                    let _ = reply.send(Err("No wallet configured; provide invoice".into()));
+                                    pending_invoice = Some(request);
+                                    continue;
+                                };
+                                let Some(msat) = invoice_request_amount_msat(&request).filter(|&m| m > 0) else {
+                                    let _ = reply.send(Err("Cannot create invoice: no exchange rate or zero amount".into()));
+                                    pending_invoice = Some(request);
+                                    continue;
+                                };
+                                match w.make_invoice(msat, request.inner.description.clone()).await {
+                                    Ok(inv) => inv,
+                                    Err(e) => {
+                                        let _ = reply.send(Err(e.to_string()));
+                                        pending_invoice = Some(request);
+                                        continue;
+                                    }
+                                }
+                            }
+                        };
+                        match app.reply_invoice_request(
+                            request.clone(),
+                            MakeInvoiceResponse { invoice: inv.clone(), payment_hash: None },
+                        ).await {
+                            Ok(_) => {
+                                let dto = invoice_request_to_dto(&request);
+                                let now_secs = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs();
+                                let entry = InvoiceRequestLogEntry {
+                                    request_id: dto.request_id.clone(),
+                                    amount_formatted: dto.amount_formatted,
+                                    currency: dto.currency,
+                                    is_fiat: dto.is_fiat,
+                                    equivalent_sats: dto.equivalent_sats,
+                                    description: dto.description,
+                                    at_secs: now_secs,
+                                    status: "accepted".into(),
+                                    error: None,
+                                    invoice: Some(inv.clone()),
+                                };
+                                let _ = sse_tx.send(SseEvent::InvoiceResult {
+                                    request_id: dto.request_id,
+                                    status: "accepted".into(),
+                                    error: None,
+                                    invoice: Some(inv),
+                                });
+                                recent_invoices.insert(0, entry);
+                                if recent_invoices.len() > MAX_RECENT_INVOICE_REQUESTS {
+                                    recent_invoices.truncate(MAX_RECENT_INVOICE_REQUESTS);
+                                }
+                                let _ = reply.send(Ok(()));
+                            }
+                            Err(e) => {
+                                pending_invoice = Some(request);
+                                let _ = reply.send(Err(e.to_string()));
+                            }
+                        }
+                    }
+                    ActorCmd::RejectInvoice { reply } => {
+                        let _ = pending_invoice.take();
+                        let _ = reply.send(());
+                    }
+                    ActorCmd::RecentInvoices { reply } => {
+                        let _ = reply.send(recent_invoices.clone());
+                    }
+                    ActorCmd::Handshake { url, reply } => {
+                        let result = run_handshake(&app, &url).await;
+                        let _ = reply.send(result);
+                    }
+                }
+            }
+            else => break,
         }
-    } else {
-        PaymentResponseContent {
-            request_id,
-            status: PaymentStatus::Success {
-                preimage: Some("demo-preimage-for-protocol-testing".to_string()),
-            },
-        }
-    };
+    }
 
-    app.reply_single_payment_request(request, status)
-        .await
-        .map_err(|e| Err::internal(e.to_string()))?;
-
-    log::info!("Payment request accepted");
-    Ok(StatusCode::OK)
+    // Cleanup
+    global.sessions.write().await.remove(&pubkey);
+    log::info!("Actor shut down for {}", app::key_to_hex(pubkey));
 }
 
-async fn api_reject(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<RejectBody>,
-) -> Result<StatusCode, ApiError> {
-    let app_guard = state.app.read().await;
-    let app = app_guard.as_ref().ok_or_else(|| Err::bad_request("App not ready"))?;
-    let request = state.pending_request.write().await.take().ok_or_else(|| Err::not_found("No pending payment request"))?;
+async fn run_handshake(app: &PortalApp, url: &str) -> Result<(), String> {
+    let parsed = parse_key_handshake_url(url)
+        .map_err(|e| format!("Invalid handshake URL: {}", e))?;
 
-    let content = PaymentResponseContent {
-        request_id: request.content.request_id.clone(),
-        status: PaymentStatus::Rejected {
-            reason: body.reason,
-        },
-    };
-    app.reply_single_payment_request(request, content)
-        .await
-        .map_err(|e| Err::internal(e.to_string()))?;
+    app.send_key_handshake(parsed).await
+        .map_err(|e| format!("Handshake send failed: {}", e))?;
 
-    log::info!("Payment request rejected");
-    Ok(StatusCode::OK)
-}
-
-async fn api_invoice_request(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<Option<InvoiceRequestDto>>, ApiError> {
-    let guard = state.pending_invoice_request.read().await;
-    Ok(Json(guard.as_ref().map(invoice_request_to_dto)))
-}
-
-async fn api_invoice_request_reply(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<InvoiceReplyBody>,
-) -> Result<StatusCode, ApiError> {
-    let app_guard = state.app.read().await;
-    let app = app_guard.as_ref().ok_or_else(|| Err::bad_request("App not ready"))?;
-    let request = state
-        .pending_invoice_request
-        .write()
-        .await
-        .take()
-        .ok_or_else(|| Err::not_found("No pending invoice request"))?;
-
-    let invoice = body.invoice.trim();
-    let (invoice, payment_hash) = if !invoice.is_empty() {
-        (invoice.to_string(), body.payment_hash)
-    } else {
-        // Create invoice via wallet (msat or fiat with exchange rate)
-        let payment_wallet = state.payment_wallet.read().await.clone();
-        let wallet = payment_wallet.as_ref().ok_or_else(|| Err::bad_request("No payment wallet configured; provide invoice in body"))?;
-        let amount_msat = invoice_request_amount_msat(&request)
-            .filter(|&m| m > 0)
-            .ok_or_else(|| Err::bad_request("Cannot create invoice: fiat has no exchange rate or amount is zero"))?;
-        let inv = wallet
-            .make_invoice(amount_msat, request.inner.description.clone())
-            .await
-            .map_err(|e| Err::internal(e.to_string()))?;
-        (inv, None)
-    };
-
-    app.reply_invoice_request(
-        request,
-        MakeInvoiceResponse {
-            invoice,
-            payment_hash,
-        },
-    )
-    .await
-    .map_err(|e| Err::internal(e.to_string()))?;
-
-    log::info!("Invoice request replied");
-    Ok(StatusCode::OK)
-}
-
-/// Reject: clear the pending invoice request **without sending any reply**.
-/// The requester will receive no invoice and will time out waiting for one.
-/// This is intentional for demo purposes — a real implementation might send an explicit error.
-async fn api_invoice_request_reject(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
-    let _ = state.pending_invoice_request.write().await.take();
-    log::info!("Invoice request rejected (no reply sent)");
-    Ok(StatusCode::OK)
-}
-
-async fn api_invoice_requests_recent(
-    State(state): State<Arc<AppState>>,
-) -> Json<Vec<InvoiceRequestLogEntry>> {
-    let recent = state.recent_invoice_requests.read().await.clone();
-    Json(recent)
-}
-
-#[derive(serde::Deserialize)]
-struct HandshakeBody {
-    url: String,
-}
-
-async fn api_handshake(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<HandshakeBody>,
-) -> Result<StatusCode, ApiError> {
-    let app = {
-        let guard = state.app.read().await;
-        guard.as_ref().ok_or_else(|| Err::internal("App not initialized"))?.clone()
-    };
-
-    let url = parse_key_handshake_url(&body.url)
-        .map_err(|e| Err::bad_request(format!("Invalid handshake URL: {}", e)))?;
-
-    // Step 1: send our pubkey to the platform.
-    app.send_key_handshake(url).await
-        .map_err(|e| Err::internal(format!("Handshake send failed: {}", e)))?;
-
-    // Step 2: wait for the auth challenge the platform sends back (up to 15s).
     let challenge = tokio::time::timeout(
-        std::time::Duration::from_secs(15),
+        Duration::from_secs(15),
         app.next_auth_challenge(),
     )
     .await
-    .map_err(|_| Err::internal("Timed out waiting for auth challenge from platform"))?
-    .map_err(|e| Err::internal(format!("Auth challenge error: {}", e)))?;
+    .map_err(|_| "Timed out waiting for auth challenge".to_string())?
+    .map_err(|e| format!("Auth challenge error: {}", e))?;
 
-    // Step 3: approve the login.
     let session_token = format!(
         "demo-{}",
         std::time::SystemTime::now()
@@ -711,8 +654,303 @@ async fn api_handshake(
         },
     )
     .await
-    .map_err(|e| Err::internal(format!("Auth reply failed: {}", e)))?;
+    .map_err(|e| format!("Auth reply failed: {}", e))?;
 
-    log::info!("Key handshake approved.");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helper: send command to actor
+// ---------------------------------------------------------------------------
+
+async fn send_cmd<T>(
+    global: &GlobalState,
+    pubkey_hex: &str,
+    make_cmd: impl FnOnce(oneshot::Sender<T>) -> ActorCmd,
+) -> Result<T, ApiError> {
+    let nostr_pk = portal::nostr::PublicKey::from_hex(pubkey_hex)
+        .map_err(|_| ApiError::bad_request("Invalid pubkey"))?;
+    let pubkey = PublicKey(nostr_pk);
+    let sessions = global.sessions.read().await;
+    let tx = sessions
+        .get(&pubkey)
+        .ok_or_else(|| ApiError::not_found("Session not found or expired"))?
+        .clone();
+    drop(sessions);
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(make_cmd(reply_tx))
+        .await
+        .map_err(|_| ApiError::internal("Actor not running"))?;
+    reply_rx
+        .await
+        .map_err(|_| ApiError::internal("Actor dropped reply"))
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let settings = config::Settings::load()?;
+
+    let global = Arc::new(GlobalState {
+        sessions: RwLock::new(HashMap::new()),
+        config: AppConfig {
+            listen_port: settings.info.listen_port,
+            default_relays: settings.nostr.default_relays.clone(),
+            max_sessions: settings.session.max_sessions,
+            session_ttl_secs: settings.session.ttl_secs,
+        },
+    });
+
+    let router = Router::new()
+        .route("/", get(serve_index))
+        .route("/api/config", get(api_config))
+        .route("/api/session", post(api_create_session))
+        .route("/api/session/ping/:pubkey_hex", post(api_ping))
+        .route("/api/events/:pubkey_hex", get(api_events))
+        .route("/api/status/:pubkey_hex", get(api_status))
+        .route("/api/handshake/:pubkey_hex", post(api_handshake))
+        .route("/api/payment-request/:pubkey_hex", get(api_payment_request))
+        .route("/api/payment-request/:pubkey_hex/accept", post(api_accept))
+        .route("/api/payment-request/:pubkey_hex/reject", post(api_reject))
+        .route("/api/invoice-request/:pubkey_hex", get(api_invoice_request))
+        .route("/api/invoice-request/:pubkey_hex/reply", post(api_invoice_reply))
+        .route("/api/invoice-request/:pubkey_hex/reject", post(api_invoice_reject))
+        .route("/api/invoice-requests/recent/:pubkey_hex", get(api_recent_invoices))
+        .layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any))
+        .with_state(global.clone());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], global.config.listen_port));
+    log::info!("portal-app-demo listening on http://{}/", addr);
+    axum::Server::bind(&addr)
+        .serve(router.into_make_service())
+        .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn serve_index() -> Html<&'static str> {
+    Html(include_str!("index.html"))
+}
+
+#[derive(Serialize)]
+struct ConfigResponse {
+    default_relays: Vec<String>,
+}
+
+async fn api_config(State(global): State<Arc<GlobalState>>) -> Json<ConfigResponse> {
+    Json(ConfigResponse {
+        default_relays: global.config.default_relays.clone(),
+    })
+}
+
+async fn api_create_session(
+    State(global): State<Arc<GlobalState>>,
+    Json(body): Json<CreateSessionRequest>,
+) -> Result<Json<CreateSessionResponse>, ApiError> {
+    // Validate relays
+    for r in &body.relays {
+        if !r.starts_with("wss://") && !r.starts_with("ws://") {
+            return Err(ApiError::bad_request(format!("Invalid relay URL: {}", r)));
+        }
+    }
+    if body.relays.is_empty() {
+        return Err(ApiError::bad_request("At least one relay is required"));
+    }
+
+    // Build keypair
+    let keypair = if let Some(ref nsec) = body.nsec {
+        let nsec = nsec.trim();
+        if nsec.is_empty() {
+            return Err(ApiError::bad_request("nsec is empty"));
+        }
+        let n = Nsec::new(nsec).map_err(|e| ApiError::bad_request(format!("Invalid nsec: {:?}", e)))?;
+        Arc::new(n.get_keypair())
+    } else if let Some(ref words) = body.mnemonic {
+        let words = words.trim();
+        if words.is_empty() {
+            return Err(ApiError::bad_request("mnemonic is empty"));
+        }
+        let m = Mnemonic::new(words).map_err(|e| ApiError::bad_request(format!("Invalid mnemonic: {:?}", e)))?;
+        Arc::new(m.get_keypair().map_err(|e| ApiError::bad_request(format!("Keypair from mnemonic: {:?}", e)))?)
+    } else {
+        return Err(ApiError::bad_request("Provide nsec or mnemonic"));
+    };
+
+    let pubkey = keypair.public_key();
+    let pubkey_bech32 = portal::nostr::nips::nip19::ToBech32::to_bech32(&*pubkey)
+        .unwrap_or_else(|_| app::key_to_hex(pubkey));
+    let pubkey_hex = app::key_to_hex(pubkey);
+
+    // Check existing session
+    {
+        let sessions = global.sessions.read().await;
+        if let Some(tx) = sessions.get(&pubkey) {
+            // Send ping to keep alive, return existing
+            let _ = tx.send(ActorCmd::Ping).await;
+            return Ok(Json(CreateSessionResponse {
+                pubkey: pubkey_bech32,
+                pubkey_hex,
+            }));
+        }
+        if sessions.len() >= global.config.max_sessions {
+            return Err(ApiError::too_many_requests("Max sessions reached"));
+        }
+    }
+
+    // Create app
+    let listener = Arc::new(NoOpRelayStatusListener);
+    let app = PortalApp::new(keypair, body.relays, listener)
+        .await
+        .map_err(|e| ApiError::internal(format!("PortalApp init: {}", e)))?;
+
+    // Build wallet
+    let wallet: Option<Arc<dyn PortalWallet>> = match body.nwc {
+        Some(ref nwc_str) if !nwc_str.trim().is_empty() => {
+            let w = NwcWallet::new(nwc_str.trim().to_string())
+                .map_err(|e| ApiError::bad_request(format!("Invalid NWC: {}", e)))?;
+            Some(Arc::new(w))
+        }
+        _ => None,
+    };
+
+    // Spawn actor
+    let (tx, rx) = mpsc::channel(32);
+    let g = Arc::clone(&global);
+    tokio::spawn(run_actor(pubkey, rx, app, wallet, g));
+
+    global.sessions.write().await.insert(pubkey, tx);
+
+    Ok(Json(CreateSessionResponse {
+        pubkey: pubkey_bech32,
+        pubkey_hex,
+    }))
+}
+
+async fn api_ping(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let nostr_pk = portal::nostr::PublicKey::from_hex(&pubkey_hex)
+        .map_err(|_| ApiError::bad_request("Invalid pubkey"))?;
+    let pubkey = PublicKey(nostr_pk);
+    let sessions = global.sessions.read().await;
+    let tx = sessions
+        .get(&pubkey)
+        .ok_or_else(|| ApiError::not_found("Session not found"))?
+        .clone();
+    drop(sessions);
+    tx.send(ActorCmd::Ping)
+        .await
+        .map_err(|_| ApiError::internal("Actor not running"))?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+async fn api_events(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let rx = send_cmd(&global, &pubkey_hex, |r| ActorCmd::Subscribe { reply: r }).await?;
+    let stream = BroadcastStream::new(rx)
+        .filter_map(|r| async move { r.ok() })
+        .map(|evt| Ok(Event::default().data(serde_json::to_string(&evt).unwrap())));
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+async fn api_status(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<Json<StatusDto>, ApiError> {
+    let status = send_cmd(&global, &pubkey_hex, |r| ActorCmd::Status { reply: r }).await?;
+    Ok(Json(status))
+}
+
+async fn api_handshake(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+    Json(body): Json<HandshakeBody>,
+) -> Result<StatusCode, ApiError> {
+    let result = send_cmd(&global, &pubkey_hex, |r| ActorCmd::Handshake {
+        url: body.url,
+        reply: r,
+    })
+    .await?;
+    result.map_err(|e| ApiError::internal(e))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn api_payment_request(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<Json<Option<PaymentRequestDto>>, ApiError> {
+    let dto = send_cmd(&global, &pubkey_hex, |r| ActorCmd::GetPayment { reply: r }).await?;
+    Ok(Json(dto))
+}
+
+async fn api_accept(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let result = send_cmd(&global, &pubkey_hex, |r| ActorCmd::AcceptPayment { reply: r }).await?;
+    result.map_err(|e| ApiError::internal(e))?;
+    Ok(StatusCode::OK)
+}
+
+async fn api_reject(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+    Json(body): Json<RejectBody>,
+) -> Result<StatusCode, ApiError> {
+    let result = send_cmd(&global, &pubkey_hex, |r| ActorCmd::RejectPayment {
+        reason: body.reason,
+        reply: r,
+    })
+    .await?;
+    result.map_err(|e| ApiError::internal(e))?;
+    Ok(StatusCode::OK)
+}
+
+async fn api_invoice_request(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<Json<Option<InvoiceRequestDto>>, ApiError> {
+    let dto = send_cmd(&global, &pubkey_hex, |r| ActorCmd::GetInvoice { reply: r }).await?;
+    Ok(Json(dto))
+}
+
+async fn api_invoice_reply(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+    Json(body): Json<InvoiceReplyBody>,
+) -> Result<StatusCode, ApiError> {
+    let result = send_cmd(&global, &pubkey_hex, |r| ActorCmd::ReplyInvoice {
+        invoice: body.invoice,
+        reply: r,
+    })
+    .await?;
+    result.map_err(|e| ApiError::internal(e))?;
+    Ok(StatusCode::OK)
+}
+
+async fn api_invoice_reject(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    send_cmd(&global, &pubkey_hex, |r| ActorCmd::RejectInvoice { reply: r }).await?;
+    Ok(StatusCode::OK)
+}
+
+async fn api_recent_invoices(
+    State(global): State<Arc<GlobalState>>,
+    Path(pubkey_hex): Path<String>,
+) -> Result<Json<Vec<InvoiceRequestLogEntry>>, ApiError> {
+    let list = send_cmd(&global, &pubkey_hex, |r| ActorCmd::RecentInvoices { reply: r }).await?;
+    Ok(Json(list))
 }


### PR DESCRIPTION
## Summary

Refactors portal-app-demo from a single-instance config-based app to a multi-user session pool with an actor model.

### Architecture

- **GlobalState**: Contains a session map of actor command senders (`RwLock<HashMap<PublicKey, mpsc::Sender<ActorCmd>>>`) and config
- **Actor per session**: Each session runs a `run_actor` task with `tokio::select!` handling:
  - Payment requests from PortalApp
  - Invoice requests (auto-accept with wallet, or store pending)
  - Actor commands via mpsc channel
  - Inactivity timeout with deadline reset on every command
- **SSE**: Real-time event streaming via broadcast channels
- **Self-cleanup**: Actor removes itself from session map on shutdown/expiry

### API Changes

All endpoints now take `:pubkey_hex` path parameter. New endpoints:
- `POST /api/session` — create session with nsec/mnemonic, relays, optional NWC
- `POST /api/session/ping/:pubkey_hex` — keepalive
- `GET /api/events/:pubkey_hex` — SSE stream
- `GET /api/config` — default relays for frontend

### Config

Simplified: removed `identity` and `wallet` sections. Added:
```toml
[session]
max_sessions = 50
ttl_secs = 7200
```

### Frontend

Complete rewrite with wizard (generate/import key, relay editor, NWC input) and SSE-driven dashboard (no polling).