### PR TITLE
fix(docs): replace inline Redoc script with hosted iframe

### DIFF
--- a/docs/sdk/api-reference-rest.md
+++ b/docs/sdk/api-reference-rest.md
@@ -1,25 +1,15 @@
 # API Reference (OpenAPI)
 
-Full interactive reference for the Portal REST API, generated from the [openapi.yaml](https://github.com/PortalTechnologiesInc/lib/blob/master/crates/portal-rest/openapi.yaml) spec.
+Full interactive reference for the Portal REST API, generated from the [`openapi.yaml`](https://github.com/PortalTechnologiesInc/lib/blob/master/crates/portal-rest/openapi.yaml) spec.
 
-<div id="redoc-container"></div>
+<iframe
+  src="https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/PortalTechnologiesInc/lib/master/crates/portal-rest/openapi.yaml&nocors"
+  width="100%"
+  height="900px"
+  style="border: none; border-radius: 6px;"
+  title="Portal REST API Reference">
+</iframe>
 
-<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
-<script>
-  Redoc.init(
-    'https://raw.githubusercontent.com/PortalTechnologiesInc/lib/master/crates/portal-rest/openapi.yaml',
-    {
-      scrollYOffset: 50,
-      hideDownloadButton: false,
-      theme: {
-        colors: { primary: { main: '#e8b468' } },
-        typography: { fontSize: '15px', fontFamily: 'inherit' }
-      }
-    },
-    document.getElementById('redoc-container')
-  );
-</script>
-
-> If the interactive viewer doesn't load, open the raw spec directly:
-> [openapi.yaml on GitHub](https://github.com/PortalTechnologiesInc/lib/blob/master/crates/portal-rest/openapi.yaml)
-> or paste the raw URL into [Redocly](https://redocly.github.io/redoc/) / [Swagger Editor](https://editor.swagger.io/).
+> If the viewer above doesn't load, open the spec directly:
+> - [openapi.yaml on GitHub](https://github.com/PortalTechnologiesInc/lib/blob/master/crates/portal-rest/openapi.yaml)
+> - Paste the raw URL into [Redocly](https://redocly.github.io/redoc/) or [Swagger Editor](https://editor.swagger.io/)


### PR DESCRIPTION
The inline `<script>` tag for Redoc was being stripped or blocked by mdBook/GitHub Pages CSP, leaving the API reference page empty.

Replace with an `<iframe>` pointing to the hosted Redocly viewer (`redocly.github.io/redoc`) which loads the `openapi.yaml` spec directly from the repo — no local scripts needed, works natively in mdBook.