### PR TITLE
feat: move register_nip05 to portal crate + auto-register on portal-rest startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Unreleased
 
+#### Changed
+- `GET /info` now includes `version` and `git_commit` fields (previously only in `GET /version`). `GET /version` kept for backward compatibility.
+
+#### Added
+- **NIP-05 auto-registration**: if `PORTAL__PROFILE__NIP05` is set to a `@getportal.cc` address, the daemon registers it with the Portal profile service at startup (one-time, cached in `~/.portal-rest/nip05.registered`). Self-hosted domains are set in the Nostr profile only, no external call.
+
 ---
 
 ### [0.4.0] - 2026-03-17
@@ -80,6 +86,9 @@ First release — Docker image available at [`getportal/sdk-daemon`](https://hub
 ## portal-app (App Library)
 
 ### Unreleased
+
+#### Changed
+- `register_nip05()` now delegates to `portal::register_nip05()` (moved to `portal` crate). UniFFI bindings unchanged.
 
 ---
 

--- a/crates/portal-app-demo/Cargo.toml
+++ b/crates/portal-app-demo/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 app = { path = "../portal-app", features = [] }
 portal-wallet = { path = "../portal-wallet" }
-portal = { path = "../portal", features = ["bindings"] }
+portal = { path = "../portal", features = ["bindings", "profile-service"] }
 
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/crates/portal-app/Cargo.toml
+++ b/crates/portal-app/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-portal = { path = "../portal", features = ["bindings"] }
+portal = { path = "../portal", features = ["bindings", "profile-service"] }
 portal-macros = { path = "../portal-macros" }
 portal-rates = { path = "../portal-rates", features = ["bindings"]}
 

--- a/crates/portal-app/src/lib.rs
+++ b/crates/portal-app/src/lib.rs
@@ -947,12 +947,11 @@ impl PortalApp {
     }
 
     pub async fn register_nip05(&self, local_part: String) -> Result<(), AppError> {
-        self.post_request_profile_service(EventContent {
-            nip_05: Some(local_part),
-            img: None,
-        })
-        .await?;
-        Ok(())
+        let nip05 = format!("{}@getportal.cc", local_part.trim().to_lowercase());
+        portal::register_nip05(&self.router.keypair().get_keys(), &nip05)
+            .await
+            .map(|_| ())
+            .map_err(|e| AppError::ProfileRegistrationError(e))
     }
 
     pub async fn next_invoice_request(

--- a/crates/portal-cli/Cargo.toml
+++ b/crates/portal-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 app = { path = "../portal-app", features = [] }
 portal-sdk = { path = "../portal-sdk", features = [] }
-portal = { path = "../portal", features = ["bindings"] }
+portal = { path = "../portal", features = ["bindings", "profile-service"] }
 portal-macros = { path = "../portal-macros" }
 
 async-trait = { workspace = true }

--- a/crates/portal-rest/Cargo.toml
+++ b/crates/portal-rest/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 portal-wallet = { path = "../portal-wallet" }
 portal-sdk = { path = "../portal-sdk" }
-portal = { version = "0.1.0", path = "../portal" }
+portal = { version = "0.1.0", path = "../portal", features = ["profile-service"] }
 portal-rates = { path = "../portal-rates" }
 portal-macros = { path = "../portal-macros" }
 

--- a/crates/portal-rest/src/main.rs
+++ b/crates/portal-rest/src/main.rs
@@ -241,6 +241,42 @@ async fn setup_background_listeners(state: &AppState) {
             Err(e) => error!("Failed to set profile from config: {e}"),
         }
     }
+
+    // Register NIP-05 with profile service (only once, tracked by local file)
+    if let Some(ref nip05) = state.settings.profile.nip05 {
+        // Only register with getportal.cc domain
+        if nip05.ends_with("@getportal.cc") {
+            let registered_file = constants::portal_rest_dir()
+                .map(|d| d.join("nip05.registered"));
+
+            let already_registered = match &registered_file {
+                Ok(path) => tokio::fs::read_to_string(path)
+                    .await
+                    .map(|s| s.trim().to_string() == nip05.trim())
+                    .unwrap_or(false),
+                Err(_) => false,
+            };
+
+            if already_registered {
+                info!("NIP-05 '{nip05}' already registered (cached), skipping");
+            } else {
+                let keys = portal::nostr::key::Keys::from_str(&state.settings.nostr.private_key)
+                    .expect("keys already validated at startup");
+                match portal::register_nip05(&keys, nip05).await {
+                    Ok(true) => {
+                        info!("NIP-05 '{nip05}' registered with profile service");
+                        if let Ok(path) = &registered_file {
+                            if let Err(e) = tokio::fs::write(path, nip05).await {
+                                warn!("Could not write NIP-05 registration cache file: {e}");
+                            }
+                        }
+                    }
+                    Ok(false) => info!("NIP-05 '{nip05}' set in profile (self-managed domain)"),
+                    Err(e) => warn!("Failed to register NIP-05 '{nip05}' with profile service (non-fatal): {e}"),
+                }
+            }
+        }
+    }
 }
 
 /// Assemble the Axum router — public routes, authenticated API, CORS, and tracing.

--- a/crates/portal-sdk/Cargo.toml
+++ b/crates/portal-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-portal = { path = "../portal" }
+portal = { path = "../portal", features = ["profile-service"] }
 
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/portal/Cargo.toml
+++ b/crates/portal/Cargo.toml
@@ -27,8 +27,9 @@ derive-new = { workspace = true }
 jwt-compact = { workspace = true }
 secp256k1 = { workspace = true }
 cdk = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, optional = true }
 
 [features]
 default = ["bindings"]
 bindings = ["uniffi", "anyhow"]
+profile-service = ["reqwest"]

--- a/crates/portal/src/lib.rs
+++ b/crates/portal/src/lib.rs
@@ -1,7 +1,12 @@
 pub mod conversation;
+#[cfg(feature = "profile-service")]
+pub mod profile_service;
 pub mod protocol;
 pub mod router;
 pub mod utils;
+
+#[cfg(feature = "profile-service")]
+pub use profile_service::register_nip05;
 
 pub use nostr;
 pub use nostr_relay_pool;

--- a/crates/portal/src/profile_service.rs
+++ b/crates/portal/src/profile_service.rs
@@ -1,0 +1,62 @@
+use nostr::event::EventBuilder;
+
+const PROFILE_SERVICE_URL: &str = "https://profile.getportal.cc";
+const GETPORTAL_DOMAIN: &str = "getportal.cc";
+
+#[derive(Debug, serde::Serialize)]
+struct ProfileServiceContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nip_05: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    img: Option<String>,
+}
+
+/// Register a NIP-05 identifier with the Portal profile service.
+///
+/// Only performs the HTTP registration if the domain is `getportal.cc`.
+/// `nip05` is the full identifier, e.g. "alice@getportal.cc" or "test@google.com".
+/// Returns Ok(true) if registered, Ok(false) if skipped (non-getportal.cc domain).
+pub async fn register_nip05(keys: &nostr::Keys, nip05: &str) -> Result<bool, String> {
+    // Parse "local@domain"
+    let mut parts = nip05.splitn(2, '@');
+    let local_part = parts.next().unwrap_or("").trim().to_lowercase();
+    let domain = parts.next().unwrap_or("").trim().to_lowercase();
+
+    if domain != GETPORTAL_DOMAIN {
+        // Not a getportal.cc address — nothing to register, user manages their own .well-known
+        return Ok(false);
+    }
+
+    if local_part.is_empty() {
+        return Err("NIP-05 local part is empty".to_string());
+    }
+
+    let content = ProfileServiceContent {
+        nip_05: Some(local_part),
+        img: None,
+    };
+    let content_json = serde_json::to_string(&content).map_err(|e| e.to_string())?;
+
+    let event = EventBuilder::text_note(&content_json)
+        .sign_with_keys(keys)
+        .map_err(|e| e.to_string())?;
+
+    let event_json = serde_json::to_string(&event).map_err(|e| e.to_string())?;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(PROFILE_SERVICE_URL)
+        .header("Content-Type", "application/json")
+        .body(event_json)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if resp.status().is_success() {
+        Ok(true)
+    } else {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        Err(format!("Profile service error {}: {}", status, body))
+    }
+}

--- a/crates/portal/src/utils.rs
+++ b/crates/portal/src/utils.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "profile-service")]
 use nostr::{
     key::PublicKey,
     nips::nip05::{Nip05Address, Nip05Profile},
@@ -12,6 +13,7 @@ pub fn random_string(lenght: usize) -> String {
         .collect()
 }
 
+#[cfg(feature = "profile-service")]
 pub async fn verify_nip05(nip05: &str, main_key: &PublicKey) -> bool {
     let address = match Nip05Address::parse(nip05) {
         Ok(address) => address,
@@ -31,6 +33,7 @@ pub async fn verify_nip05(nip05: &str, main_key: &PublicKey) -> bool {
     nostr::nips::nip05::verify_from_json(&main_key, &address, &nip05)
 }
 
+#[cfg(feature = "profile-service")]
 pub async fn fetch_nip05_profile(nip05: &str) -> anyhow::Result<Nip05Profile> {
     let address = Nip05Address::parse(nip05)?;
 


### PR DESCRIPTION
Moves NIP-05 registration logic from portal-app to portal crate.

**portal**: new `register_nip05(keys, local_part)` in `profile_service` module — signs Nostr event, POSTs to profile.getportal.cc

**portal-app**: delegates to `portal::register_nip05()`; UniFFI bindings unchanged

**portal-rest**: if `PORTAL__PROFILE__NIP05` is set, auto-registers on startup (warn on failure, never blocks)