### PR TITLE
feat(portal-rest): merge version fields into GET /info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Unreleased
 
+#### Changed
+- `GET /info` now also returns `version` and `git_commit` fields (previously only in `GET /version`). `/version` is kept for backward compatibility.
+
 ---
 
 ### [0.4.0] - 2026-03-17

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -442,7 +442,7 @@ paths:
   /info:
     get:
       summary: Get server info
-      description: Returns the server's Nostr public key. Requires authentication.
+      description: Returns the server's Nostr public key, version, and git commit. Requires authentication.
       responses:
         "200":
           description: Server info
@@ -454,10 +454,22 @@ paths:
                   - properties:
                       data:
                         type: object
+                        required:
+                          - public_key
+                          - version
+                          - git_commit
                         properties:
-                          pubkey:
+                          public_key:
                             type: string
                             description: Hex-encoded Nostr public key
+                          version:
+                            type: string
+                            description: Daemon version
+                            example: "0.4.0"
+                          git_commit:
+                            type: string
+                            description: Git commit hash
+                            example: "abc1234"
 
   /well-known/nostr.json:
     get:

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -173,6 +173,8 @@ pub async fn info(
 ) -> ApiResult<InfoResponse> {
     Ok(ok(InfoResponse {
         public_key: state.public_key.clone(),
+        version: crate::APP_VERSION,
+        git_commit: crate::GIT_COMMIT,
     }))
 }
 

--- a/crates/portal-rest/src/response.rs
+++ b/crates/portal-rest/src/response.rs
@@ -132,6 +132,8 @@ pub struct VersionResponse {
 #[derive(Debug, Serialize)]
 pub struct InfoResponse {
     pub public_key: String,
+    pub version: &'static str,
+    pub git_commit: &'static str,
 }
 
 /// NIP-05 `.well-known/nostr.json` content.


### PR DESCRIPTION
## Summary

Consolidates `GET /version` and `GET /info` into a single public endpoint.

### Before
- `GET /version` → `{ version, git_commit }`
- `GET /info` → `{ public_key }`

### After
- `GET /info` → `{ public_key, version, git_commit }`
- `GET /version` → unchanged (kept for backward compatibility)

`GET /wallet/info` is unaffected (still requires auth).