### PR TITLE
feat(portal-rest): add age verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `GET /info` now includes `version` and `git_commit` fields (previously only in `GET /version`). `GET /version` kept for backward compatibility.
 
 #### Added
-- **Age verification**: `POST /verification/sessions` creates a browser-based age verification session via Portal's verification service. Returns a `session_url` to redirect the user to; requires `[verification] api_key` in config. Relay URLs default to the `[nostr]` config if not provided.
-- **Cashu token request**: `POST /payments/cashu/request-token` requests a Cashu token from a recipient Portal wallet (mint: `https://mint.getportal.cc`, unit: `multi`). Returns a `stream_id` for async polling.
-- TS SDK: `createVerificationSession()` and `requestPortalToken()` methods
-- Example: `examples/age-verification.js` — end-to-end age verification flow
+- **Age verification**: `POST /verification/sessions` creates a browser-based age verification session AND automatically starts listening for the verification token in a single call. Returns session info plus a `stream_id` to poll for the Cashu token result. Requires `[verification] api_key` in config. Relay URLs default to the `[nostr]` config if not provided.
+- **Verification token request**: `POST /verification/token` requests a verification token from a user who already holds one (e.g. mobile app verified users). Returns a `stream_id` for async polling.
+- TS SDK: `createVerificationSession()` now returns `AsyncOperation<CashuResponseStatus>` — use `poll()` or `done` to wait for the token. `requestVerificationToken()` for the mobile flow.
+- Example: `examples/age-verification.js` — simplified single-call age verification flow
 - **NIP-05 auto-registration**: if `PORTAL__PROFILE__NIP05` is set to a `@getportal.cc` address, the daemon registers it with the Portal profile service at startup (one-time, cached in `~/.portal-rest/nip05.registered`). Self-hosted domains are set in the Nostr profile only, no external call.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `GET /info` now includes `version` and `git_commit` fields (previously only in `GET /version`). `GET /version` kept for backward compatibility.
 
 #### Added
+- **Age verification**: `POST /verification/sessions` creates a browser-based age verification session via Portal's verification service. Returns a `session_url` to redirect the user to; requires `[verification] api_key` in config. Relay URLs default to the `[nostr]` config if not provided.
+- **Cashu token request**: `POST /payments/cashu/request-token` requests a Cashu token from a recipient Portal wallet (mint: `https://mint.getportal.cc`, unit: `multi`). Returns a `stream_id` for async polling.
+- TS SDK: `createVerificationSession()` and `requestPortalToken()` methods
+- Example: `examples/age-verification.js` — end-to-end age verification flow
 - **NIP-05 auto-registration**: if `PORTAL__PROFILE__NIP05` is set to a `@getportal.cc` address, the daemon registers it with the Portal profile service at startup (one-time, cached in `~/.portal-rest/nip05.registered`). Self-hosted domains are set in the Nostr profile only, no external call.
 
 ---

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -778,13 +778,11 @@ export class PortalClient {
    */
   public async requestPortalToken(
     recipientKey: string,
-    subkeys: string[],
-    amount: number
+    subkeys: string[]
   ): Promise<AsyncOperation<CashuResponseStatus>> {
     const resp = await this.post<{ stream_id: string }>('/payments/cashu/request-token', {
       recipient_key: recipientKey,
       subkeys,
-      amount,
     });
     const done = this.registerStream(resp.stream_id).then(
       (event) => event.status as CashuResponseStatus

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -23,6 +23,7 @@ import {
   IssueJwtResponse,
   VerifyJwtResponse,
   CashuResponseStatus,
+  VerificationSessionResponse,
   WalletInfoResponse,
   VersionResponse,
   InfoResponse,
@@ -749,5 +750,45 @@ export class PortalClient {
   public async getEvents(streamId: string, after?: number): Promise<EventsResponse> {
     const q = after !== undefined ? `?after=${after}` : '';
     return this.get<EventsResponse>(`/events/${encodeURIComponent(streamId)}${q}`);
+  }
+
+  // ---- Verification ----
+
+  /**
+   * Initiate a browser-based age verification session.
+   *
+   * Returns a `VerificationSessionResponse` with a `session_url` to redirect the
+   * user to and a `session_id` for tracking the result.
+   *
+   * Requires `[verification] api_key` in portal-rest config.
+   */
+  public async initiateBrowserSession(relayUrls?: string[]): Promise<VerificationSessionResponse> {
+    return this.post<VerificationSessionResponse>('/verification/sessions', {
+      relays: relayUrls,
+    });
+  }
+
+  // ---- Portal Token ----
+
+  /**
+   * Request a Cashu token from a recipient Portal wallet.
+   *
+   * Uses the Portal mint (`https://mint.getportal.cc`) with unit `multi`.
+   * Returns the `stream_id`; poll via `getEvents(streamId)` or use `onEvent`.
+   */
+  public async requestPortalToken(
+    recipientKey: string,
+    subkeys: string[],
+    amount: number
+  ): Promise<AsyncOperation<CashuResponseStatus>> {
+    const resp = await this.post<{ stream_id: string }>('/payments/cashu/request-token', {
+      recipient_key: recipientKey,
+      subkeys,
+      amount,
+    });
+    const done = this.registerStream(resp.stream_id).then(
+      (event) => event.status as CashuResponseStatus
+    );
+    return { streamId: resp.stream_id, done };
   }
 }

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -762,7 +762,7 @@ export class PortalClient {
    *
    * Requires `[verification] api_key` in portal-rest config.
    */
-  public async initiateBrowserSession(relayUrls?: string[]): Promise<VerificationSessionResponse> {
+  public async createVerificationSession(relayUrls?: string[]): Promise<VerificationSessionResponse> {
     return this.post<VerificationSessionResponse>('/verification/sessions', {
       relays: relayUrls,
     });

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -757,15 +757,22 @@ export class PortalClient {
   /**
    * Initiate a browser-based age verification session.
    *
-   * Returns a `VerificationSessionResponse` with a `session_url` to redirect the
-   * user to and a `session_id` for tracking the result.
+   * Creates the verification session AND automatically starts listening for the
+   * verification token. Returns session info plus an `AsyncOperation` — use
+   * `poll()` or `done` to wait for the Cashu token result.
    *
    * Requires `[verification] api_key` in portal-rest config.
    */
-  public async createVerificationSession(relayUrls?: string[]): Promise<VerificationSessionResponse> {
-    return this.post<VerificationSessionResponse>('/verification/sessions', {
+  public async createVerificationSession(relayUrls?: string[]): Promise<
+    VerificationSessionResponse & AsyncOperation<CashuResponseStatus>
+  > {
+    const resp = await this.post<VerificationSessionResponse>('/verification/sessions', {
       relays: relayUrls,
     });
+    const done = this.registerStream(resp.stream_id).then(
+      (event) => event.status as CashuResponseStatus
+    );
+    return { ...resp, streamId: resp.stream_id, done };
   }
 
   // ---- Verification Token ----

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -780,7 +780,7 @@ export class PortalClient {
     recipientKey: string,
     subkeys: string[]
   ): Promise<AsyncOperation<CashuResponseStatus>> {
-    const resp = await this.post<{ stream_id: string }>('/payments/cashu/request-token', {
+    const resp = await this.post<{ stream_id: string }>('/verification/token', {
       recipient_key: recipientKey,
       subkeys,
     });

--- a/crates/portal-rest/clients/ts/src/client.ts
+++ b/crates/portal-rest/clients/ts/src/client.ts
@@ -768,7 +768,7 @@ export class PortalClient {
     });
   }
 
-  // ---- Portal Token ----
+  // ---- Verification Token ----
 
   /**
    * Request a Cashu token from a recipient Portal wallet.
@@ -776,7 +776,7 @@ export class PortalClient {
    * Uses the Portal mint (`https://mint.getportal.cc`) with unit `multi`.
    * Returns the `stream_id`; poll via `getEvents(streamId)` or use `onEvent`.
    */
-  public async requestPortalToken(
+  public async requestVerificationToken(
     recipientKey: string,
     subkeys: string[]
   ): Promise<AsyncOperation<CashuResponseStatus>> {

--- a/crates/portal-rest/clients/ts/src/index.ts
+++ b/crates/portal-rest/clients/ts/src/index.ts
@@ -60,6 +60,13 @@ export {
   BurnCashuRequest,
   CashuResponseStatus,
 
+  // Verification
+  InitiateBrowserSessionRequest,
+  VerificationSessionResponse,
+
+  // Portal Token
+  RequestPortalTokenRequest,
+
   // Relays
   RelayRequest,
 

--- a/crates/portal-rest/clients/ts/src/index.ts
+++ b/crates/portal-rest/clients/ts/src/index.ts
@@ -65,7 +65,7 @@ export {
   VerificationSessionResponse,
 
   // Portal Token
-  RequestPortalTokenRequest,
+  RequestVerificationTokenRequest,
 
   // Relays
   RelayRequest,

--- a/crates/portal-rest/clients/ts/src/index.ts
+++ b/crates/portal-rest/clients/ts/src/index.ts
@@ -61,7 +61,7 @@ export {
   CashuResponseStatus,
 
   // Verification
-  InitiateBrowserSessionRequest,
+  CreateVerificationSessionRequest,
   VerificationSessionResponse,
 
   // Portal Token

--- a/crates/portal-rest/clients/ts/src/types.ts
+++ b/crates/portal-rest/clients/ts/src/types.ts
@@ -323,8 +323,8 @@ export type CashuResponseStatus =
 
 // ---- Verification ----
 
-export interface InitiateBrowserSessionRequest {
-  /** Relay URLs to use for the verification session. Defaults to Portal defaults if omitted. */
+export interface CreateVerificationSessionRequest {
+  /** Relay URLs to use for the verification session. Defaults to the relays configured in the [nostr] section of the config if omitted. */
   relays?: string[];
 }
 

--- a/crates/portal-rest/clients/ts/src/types.ts
+++ b/crates/portal-rest/clients/ts/src/types.ts
@@ -321,6 +321,28 @@ export type CashuResponseStatus =
   | { status: 'insufficient_funds' }
   | { status: 'rejected'; reason?: string };
 
+// ---- Verification ----
+
+export interface InitiateBrowserSessionRequest {
+  /** Relay URLs to use for the verification session. Defaults to Portal defaults if omitted. */
+  relays?: string[];
+}
+
+export interface VerificationSessionResponse {
+  session_id: string;
+  session_url: string;
+  ephemeral_npub: string;
+  expires_at: number;
+}
+
+// ---- Portal Token (Cashu from Portal wallet) ----
+
+export interface RequestPortalTokenRequest {
+  recipient_key: string;
+  subkeys: string[];
+  amount: number;
+}
+
 // ---- Relays ----
 
 export interface RelayRequest {

--- a/crates/portal-rest/clients/ts/src/types.ts
+++ b/crates/portal-rest/clients/ts/src/types.ts
@@ -340,7 +340,6 @@ export interface VerificationSessionResponse {
 export interface RequestPortalTokenRequest {
   recipient_key: string;
   subkeys: string[];
-  amount: number;
 }
 
 // ---- Relays ----

--- a/crates/portal-rest/clients/ts/src/types.ts
+++ b/crates/portal-rest/clients/ts/src/types.ts
@@ -337,7 +337,7 @@ export interface VerificationSessionResponse {
 
 // ---- Portal Token (Cashu from Portal wallet) ----
 
-export interface RequestPortalTokenRequest {
+export interface RequestVerificationTokenRequest {
   recipient_key: string;
   subkeys: string[];
 }

--- a/crates/portal-rest/clients/ts/src/types.ts
+++ b/crates/portal-rest/clients/ts/src/types.ts
@@ -333,6 +333,7 @@ export interface VerificationSessionResponse {
   session_url: string;
   ephemeral_npub: string;
   expires_at: number;
+  stream_id: string;
 }
 
 // ---- Portal Token (Cashu from Portal wallet) ----

--- a/crates/portal-rest/example.config.toml
+++ b/crates/portal-rest/example.config.toml
@@ -52,6 +52,12 @@ ln_backend = "none"
 path = "portal-rest.db"
 
 
+## Age verification settings. Required for the POST /verification/sessions endpoint.
+## Get your API key from https://verify.getportal.cc
+# [verification]
+# api_key = "your-api-key-here"
+
+
 ## Optional Nostr profile metadata. Set any combination of fields to publish
 ## your profile on the Nostr network at startup. Omit the section or leave
 ## fields commented out to skip.

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -409,7 +409,7 @@ components:
           type: string
       additionalProperties: true
 
-    InitiateBrowserSessionRequest:
+    CreateVerificationSessionRequest:
       type: object
       properties:
         relays:
@@ -418,7 +418,7 @@ components:
             type: string
           description: |
             Relay WebSocket URLs for the verification session.
-            Defaults to ["wss://relay.damus.io", "wss://relay.getportal.cc"] if omitted.
+            Defaults to the relays configured in the [nostr] section of the config if omitted.
 
     VerificationSessionResponse:
       type: object
@@ -990,7 +990,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InitiateBrowserSessionRequest'
+              $ref: '#/components/schemas/CreateVerificationSessionRequest'
       responses:
         "200":
           description: Verification session created

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -438,7 +438,7 @@ components:
           format: uint64
           description: Unix timestamp when the session expires
 
-    RequestPortalTokenRequest:
+    RequestVerificationTokenRequest:
       type: object
       required: [recipient_key, subkeys]
       properties:
@@ -451,8 +451,7 @@ components:
             type: string
           description: Optional subkeys to include
       description: |
-        Request a Portal verification token. The token amount is set server-side
-        (currently 1 unit) and cannot be overridden by the client.
+        Request a verification token from a recipient Portal wallet.
 
 paths:
   /health:
@@ -1021,10 +1020,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestPortalTokenRequest'
+              $ref: '#/components/schemas/RequestVerificationTokenRequest'
       responses:
         "201":
-          description: Portal token request initiated
+          description: Verification token request initiated
           content:
             application/json:
               schema:

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -1005,16 +1005,15 @@ paths:
         "500":
           description: Verification service error
 
-  /payments/cashu/request-token:
+  /verification/token:
     post:
       tags:
-        - Payments
-        - Cashu
-      summary: Request a Cashu token from a recipient Portal wallet
+        - Verification
+      summary: Request a verification token from a recipient Portal wallet
       description: |
-        Requests a Cashu token from a recipient Portal wallet using the Portal mint
-        (`https://mint.getportal.cc`) with unit `multi`. Returns a stream_id for polling.
-        Poll GET /events/{stream_id} for the `cashu_response` event.
+        Requests a verification token (Cashu) from a recipient Portal wallet using the
+        Portal mint (`https://mint.getportal.cc`) with unit `multi`. Returns a stream_id
+        for polling. Poll GET /events/{stream_id} for the `cashu_response` event.
       requestBody:
         required: true
         content:

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -409,6 +409,52 @@ components:
           type: string
       additionalProperties: true
 
+    InitiateBrowserSessionRequest:
+      type: object
+      properties:
+        relays:
+          type: array
+          items:
+            type: string
+          description: |
+            Relay WebSocket URLs for the verification session.
+            Defaults to ["wss://relay.damus.io", "wss://relay.getportal.cc"] if omitted.
+
+    VerificationSessionResponse:
+      type: object
+      required: [session_id, session_url, ephemeral_npub, expires_at]
+      properties:
+        session_id:
+          type: string
+          description: Unique verification session identifier
+        session_url:
+          type: string
+          description: URL to redirect the user to for verification
+        ephemeral_npub:
+          type: string
+          description: Ephemeral Nostr public key for this session
+        expires_at:
+          type: integer
+          format: uint64
+          description: Unix timestamp when the session expires
+
+    RequestPortalTokenRequest:
+      type: object
+      required: [recipient_key, subkeys, amount]
+      properties:
+        recipient_key:
+          type: string
+          description: Hex-encoded recipient public key
+        subkeys:
+          type: array
+          items:
+            type: string
+          description: Optional subkeys to include
+        amount:
+          type: integer
+          format: uint64
+          description: Amount of tokens to request
+
 paths:
   /health:
     get:
@@ -928,3 +974,65 @@ paths:
                         $ref: '#/components/schemas/EventsResponse'
         "404":
           description: Stream not found
+
+
+  /verification/sessions:
+    post:
+      tags:
+        - Verification
+      summary: Initiate a browser-based age verification session
+      description: |
+        Calls the Portal verification service to create a new browser session.
+        Returns a session URL to redirect the user to for identity/age verification.
+        Requires `[verification] api_key` in the portal-rest configuration.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitiateBrowserSessionRequest'
+      responses:
+        "200":
+          description: Verification session created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/VerificationSessionResponse'
+        "400":
+          description: Verification not configured or invalid request
+        "500":
+          description: Verification service error
+
+  /payments/cashu/request-token:
+    post:
+      tags:
+        - Payments
+        - Cashu
+      summary: Request a Cashu token from a recipient Portal wallet
+      description: |
+        Requests a Cashu token from a recipient Portal wallet using the Portal mint
+        (`https://mint.getportal.cc`) with unit `multi`. Returns a stream_id for polling.
+        Poll GET /events/{stream_id} for the `cashu_response` event.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestPortalTokenRequest'
+      responses:
+        "201":
+          description: Portal token request initiated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/StreamIdResponse'
+        "400":
+          description: Invalid recipient key or subkeys

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -440,7 +440,7 @@ components:
 
     RequestPortalTokenRequest:
       type: object
-      required: [recipient_key, subkeys, amount]
+      required: [recipient_key, subkeys]
       properties:
         recipient_key:
           type: string
@@ -450,10 +450,9 @@ components:
           items:
             type: string
           description: Optional subkeys to include
-        amount:
-          type: integer
-          format: uint64
-          description: Amount of tokens to request
+      description: |
+        Request a Portal verification token. The token amount is set server-side
+        (currently 1 unit) and cannot be overridden by the client.
 
 paths:
   /health:

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -422,7 +422,7 @@ components:
 
     VerificationSessionResponse:
       type: object
-      required: [session_id, session_url, ephemeral_npub, expires_at]
+      required: [session_id, session_url, ephemeral_npub, expires_at, stream_id]
       properties:
         session_id:
           type: string
@@ -437,6 +437,9 @@ components:
           type: integer
           format: uint64
           description: Unix timestamp when the session expires
+        stream_id:
+          type: string
+          description: Stream ID to poll for the verification token result via GET /events/{stream_id}
 
     RequestVerificationTokenRequest:
       type: object
@@ -980,8 +983,10 @@ paths:
         - Verification
       summary: Initiate a browser-based age verification session
       description: |
-        Calls the Portal verification service to create a new browser session.
-        Returns a session URL to redirect the user to for identity/age verification.
+        Creates a verification session AND automatically starts listening for the
+        verification token. Returns session info (including `session_url` to redirect
+        the user to) plus a `stream_id` to poll for the Cashu token result.
+        Poll `GET /events/{stream_id}` for a `cashu_response` event containing the token.
         Requires `[verification] api_key` in the portal-rest configuration.
       requestBody:
         required: false
@@ -1009,11 +1014,15 @@ paths:
     post:
       tags:
         - Verification
-      summary: Request a verification token from a recipient Portal wallet
+      summary: Request a verification token from a user who already holds one
       description: |
-        Requests a verification token (Cashu) from a recipient Portal wallet using the
-        Portal mint (`https://mint.getportal.cc`) with unit `multi`. Returns a stream_id
-        for polling. Poll GET /events/{stream_id} for the `cashu_response` event.
+        Requests a verification token (Cashu) from a recipient who already has a token
+        in their Portal wallet (e.g. a mobile app user who completed verification previously).
+        Uses the Portal mint (`https://mint.getportal.cc`) with unit `multi`. Returns a
+        stream_id for polling. Poll GET /events/{stream_id} for the `cashu_response` event.
+
+        For new browser-based verification, use `POST /verification/sessions` instead — it
+        handles the full flow (session creation + token listening) in a single call.
       requestBody:
         required: true
         content:

--- a/crates/portal-rest/src/command.rs
+++ b/crates/portal-rest/src/command.rs
@@ -75,6 +75,20 @@ pub struct RequestCashuRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct InitiateBrowserSessionRequest {
+    /// Relay URLs to use for the verification session. Defaults to
+    /// ["wss://relay.damus.io", "wss://relay.getportal.cc"] if not set.
+    pub relays: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RequestPortalTokenRequest {
+    pub recipient_key: String,
+    pub subkeys: Vec<String>,
+    pub amount: u64,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SendCashuDirectRequest {
     pub main_key: String,
     pub subkeys: Vec<String>,

--- a/crates/portal-rest/src/command.rs
+++ b/crates/portal-rest/src/command.rs
@@ -82,7 +82,7 @@ pub struct CreateVerificationSessionRequest {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct RequestPortalTokenRequest {
+pub struct RequestVerificationTokenRequest {
     pub recipient_key: String,
     pub subkeys: Vec<String>,
 }

--- a/crates/portal-rest/src/command.rs
+++ b/crates/portal-rest/src/command.rs
@@ -85,7 +85,6 @@ pub struct CreateVerificationSessionRequest {
 pub struct RequestPortalTokenRequest {
     pub recipient_key: String,
     pub subkeys: Vec<String>,
-    pub amount: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/portal-rest/src/command.rs
+++ b/crates/portal-rest/src/command.rs
@@ -75,9 +75,9 @@ pub struct RequestCashuRequest {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct InitiateBrowserSessionRequest {
+pub struct CreateVerificationSessionRequest {
     /// Relay URLs to use for the verification session. Defaults to
-    /// ["wss://relay.damus.io", "wss://relay.getportal.cc"] if not set.
+    /// the relays configured in the `[nostr]` section of the config if not set.
     pub relays: Option<Vec<String>>,
 }
 

--- a/crates/portal-rest/src/config.rs
+++ b/crates/portal-rest/src/config.rs
@@ -18,6 +18,7 @@ pub struct Settings {
     pub profile: ProfileSettings,
     #[serde(default)]
     pub logging: LoggingSettings,
+    #[serde(default)]
     pub verification: Option<VerificationSettings>,
 }
 

--- a/crates/portal-rest/src/config.rs
+++ b/crates/portal-rest/src/config.rs
@@ -18,6 +18,12 @@ pub struct Settings {
     pub profile: ProfileSettings,
     #[serde(default)]
     pub logging: LoggingSettings,
+    pub verification: Option<VerificationSettings>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct VerificationSettings {
+    pub api_key: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -1027,7 +1027,31 @@ pub async fn create_verification_session(
     let ephemeral_key = PublicKey::parse(&api_resp.ephemeral_npub)
         .map_err(|e| internal_error(format!("Invalid ephemeral_npub from verification service: {e}")))?;
 
-    // Create a cashu request for the verification token
+    let stream_id = spawn_verification_token_request(
+        state.sdk.clone(),
+        &state.events,
+        ephemeral_key,
+        vec![],
+    )
+    .await;
+
+    Ok(ok(VerificationSessionResponse {
+        session_id: api_resp.session_id,
+        session_url: api_resp.session_url,
+        ephemeral_npub: api_resp.ephemeral_npub,
+        expires_at: api_resp.expires_at,
+        stream_id,
+    }))
+}
+
+/// Shared helper: creates a verification token request stream, spawns a
+/// background task that calls `sdk.request_cashu`, and returns the `stream_id`.
+async fn spawn_verification_token_request(
+    sdk: Arc<portal_sdk::PortalSDK>,
+    events: &crate::events::EventStore,
+    recipient: PublicKey,
+    subkeys: Vec<PublicKey>,
+) -> String {
     let expires_at = Timestamp::now_plus_seconds(300);
     let content = CashuRequestContent {
         mint_url: VERIFICATION_MINT_URL.to_string(),
@@ -1037,17 +1061,14 @@ pub async fn create_verification_session(
         expires_at,
     };
 
-    let stream_id = state
-        .events
+    let stream_id = events
         .new_stream("cashu_portal_token_request", None)
         .await;
 
-    // Spawn background task to request the token (same logic as request_verification_token)
-    let sdk = state.sdk.clone();
-    let events = state.events.clone();
+    let events = events.clone();
     let sid = stream_id.clone();
     tokio::spawn(async move {
-        match sdk.request_cashu(ephemeral_key, vec![], content).await {
+        match sdk.request_cashu(recipient, subkeys, content).await {
             Ok(Some(r)) => {
                 events
                     .push(&sid, NotificationData::CashuResponse { status: r.status })
@@ -1068,7 +1089,7 @@ pub async fn create_verification_session(
                     .push(
                         &sid,
                         NotificationData::Error {
-                            reason: format!("Failed to request portal token: {e}"),
+                            reason: format!("Failed to request verification token: {e}"),
                         },
                     )
                     .await;
@@ -1076,13 +1097,7 @@ pub async fn create_verification_session(
         }
     });
 
-    Ok(ok(VerificationSessionResponse {
-        session_id: api_resp.session_id,
-        session_url: api_resp.session_url,
-        ephemeral_npub: api_resp.ephemeral_npub,
-        expires_at: api_resp.expires_at,
-        stream_id,
-    }))
+    stream_id
 }
 
 // POST /verification/token
@@ -1094,52 +1109,13 @@ pub async fn request_verification_token(
         hex_to_pubkey(&req.recipient_key).map_err(|e| bad_request(format!("Invalid recipient key: {e}")))?;
     let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
 
-    let expires_at = Timestamp::now_plus_seconds(300);
-    let content = CashuRequestContent {
-        mint_url: VERIFICATION_MINT_URL.to_string(),
-        unit: VERIFICATION_TICKET_UNIT.to_string(),
-        amount: VERIFICATION_TOKEN_AMOUNT,
-        request_id: Uuid::new_v4().to_string(),
-        expires_at,
-    };
-
-    let stream_id = state
-        .events
-        .new_stream("cashu_portal_token_request", None)
-        .await;
-
-    let sdk = state.sdk.clone();
-    let events = state.events.clone();
-    let sid = stream_id.clone();
-    tokio::spawn(async move {
-        match sdk.request_cashu(recipient_key, subkeys, content).await {
-            Ok(Some(r)) => {
-                events
-                    .push(&sid, NotificationData::CashuResponse { status: r.status })
-                    .await;
-            }
-            Ok(None) => {
-                events
-                    .push(
-                        &sid,
-                        NotificationData::Error {
-                            reason: "No response from recipient".to_string(),
-                        },
-                    )
-                    .await;
-            }
-            Err(e) => {
-                events
-                    .push(
-                        &sid,
-                        NotificationData::Error {
-                            reason: format!("Failed to request portal token: {e}"),
-                        },
-                    )
-                    .await;
-            }
-        }
-    });
+    let stream_id = spawn_verification_token_request(
+        state.sdk.clone(),
+        &state.events,
+        recipient_key,
+        subkeys,
+    )
+    .await;
 
     Ok(created(StreamResponse { stream_id }))
 }

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -968,6 +968,12 @@ pub async fn get_events(
     Ok(ok(EventsResponse { stream_id, events }))
 }
 
+// ── Age Verification constants ────────────────────────────────────────────────
+const VERIFICATION_SERVICE_URL: &str = "https://verify.getportal.cc/verify/sessions";
+const VERIFICATION_MINT_URL: &str = "https://mint.getportal.cc";
+const VERIFICATION_TICKET_UNIT: &str = "multi";
+const VERIFICATION_TOKEN_AMOUNT: u64 = 1;
+
 // POST /verification/sessions
 pub async fn create_verification_session(
     State(state): State<AppState>,
@@ -996,7 +1002,7 @@ pub async fn create_verification_session(
 
     let client = reqwest::Client::new();
     let resp = client
-        .post("https://verify.getportal.cc/verify/sessions")
+        .post(VERIFICATION_SERVICE_URL)
         .header("X-Api-Key", &verification.api_key)
         .json(&VerifySessionRequest { relays })
         .send()
@@ -1034,12 +1040,10 @@ pub async fn request_verification_token(
         hex_to_pubkey(&req.recipient_key).map_err(|e| bad_request(format!("Invalid recipient key: {e}")))?;
     let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
 
-    const VERIFICATION_TOKEN_AMOUNT: u64 = 1;
-
     let expires_at = Timestamp::now_plus_seconds(300);
     let content = CashuRequestContent {
-        mint_url: "https://mint.getportal.cc".to_string(),
-        unit: "multi".to_string(),
+        mint_url: VERIFICATION_MINT_URL.to_string(),
+        unit: VERIFICATION_TICKET_UNIT.to_string(),
         amount: VERIFICATION_TOKEN_AMOUNT,
         request_id: Uuid::new_v4().to_string(),
         expires_at,

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -1034,11 +1034,13 @@ pub async fn request_portal_token(
         hex_to_pubkey(&req.recipient_key).map_err(|e| bad_request(format!("Invalid recipient key: {e}")))?;
     let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
 
+    const VERIFICATION_TOKEN_AMOUNT: u64 = 1;
+
     let expires_at = Timestamp::now_plus_seconds(300);
     let content = CashuRequestContent {
         mint_url: "https://mint.getportal.cc".to_string(),
         unit: "multi".to_string(),
-        amount: req.amount,
+        amount: VERIFICATION_TOKEN_AMOUNT,
         request_id: Uuid::new_v4().to_string(),
         expires_at,
     };

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -1025,7 +1025,7 @@ pub async fn create_verification_session(
     }))
 }
 
-// POST /payments/cashu/request-token
+// POST /verification/token
 pub async fn request_verification_token(
     State(state): State<AppState>,
     Json(req): Json<crate::command::RequestVerificationTokenRequest>,

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -967,3 +967,124 @@ pub async fn get_events(
 
     Ok(ok(EventsResponse { stream_id, events }))
 }
+
+// POST /verification/sessions
+pub async fn initiate_browser_session(
+    State(state): State<AppState>,
+    Json(req): Json<crate::command::InitiateBrowserSessionRequest>,
+) -> ApiResult<VerificationSessionResponse> {
+    let verification = state
+        .settings
+        .verification
+        .as_ref()
+        .ok_or_else(|| bad_request("Verification not configured — add [verification] api_key to config"))?;
+
+    let relays = req.relays.unwrap_or_else(|| {
+        vec![
+            "wss://relay.damus.io".to_string(),
+            "wss://relay.getportal.cc".to_string(),
+        ]
+    });
+
+    #[derive(serde::Serialize)]
+    struct VerifySessionRequest {
+        relays: Vec<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct VerifySessionApiResponse {
+        session_id: String,
+        session_url: String,
+        ephemeral_npub: String,
+        expires_at: u64,
+    }
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://verify.getportal.cc/verify/sessions")
+        .header("X-Api-Key", &verification.api_key)
+        .json(&VerifySessionRequest { relays })
+        .send()
+        .await
+        .map_err(|e| internal_error(format!("Failed to call verification service: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(internal_error(format!(
+            "Verification service returned {}: {}",
+            status, body
+        )));
+    }
+
+    let api_resp: VerifySessionApiResponse = resp
+        .json()
+        .await
+        .map_err(|e| internal_error(format!("Failed to parse verification response: {e}")))?;
+
+    Ok(ok(VerificationSessionResponse {
+        session_id: api_resp.session_id,
+        session_url: api_resp.session_url,
+        ephemeral_npub: api_resp.ephemeral_npub,
+        expires_at: api_resp.expires_at,
+    }))
+}
+
+// POST /payments/cashu/request-token
+pub async fn request_portal_token(
+    State(state): State<AppState>,
+    Json(req): Json<crate::command::RequestPortalTokenRequest>,
+) -> ApiResult<StreamResponse> {
+    let recipient_key =
+        hex_to_pubkey(&req.recipient_key).map_err(|e| bad_request(format!("Invalid recipient key: {e}")))?;
+    let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
+
+    let expires_at = Timestamp::now_plus_seconds(300);
+    let content = CashuRequestContent {
+        mint_url: "https://mint.getportal.cc".to_string(),
+        unit: "multi".to_string(),
+        amount: req.amount,
+        request_id: Uuid::new_v4().to_string(),
+        expires_at,
+    };
+
+    let stream_id = state
+        .events
+        .new_stream("cashu_portal_token_request", None)
+        .await;
+
+    let sdk = state.sdk.clone();
+    let events = state.events.clone();
+    let sid = stream_id.clone();
+    tokio::spawn(async move {
+        match sdk.request_cashu(recipient_key, subkeys, content).await {
+            Ok(Some(r)) => {
+                events
+                    .push(&sid, NotificationData::CashuResponse { status: r.status })
+                    .await;
+            }
+            Ok(None) => {
+                events
+                    .push(
+                        &sid,
+                        NotificationData::Error {
+                            reason: "No response from recipient".to_string(),
+                        },
+                    )
+                    .await;
+            }
+            Err(e) => {
+                events
+                    .push(
+                        &sid,
+                        NotificationData::Error {
+                            reason: format!("Failed to request portal token: {e}"),
+                        },
+                    )
+                    .await;
+            }
+        }
+    });
+
+    Ok(created(StreamResponse { stream_id }))
+}

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -1026,9 +1026,9 @@ pub async fn create_verification_session(
 }
 
 // POST /payments/cashu/request-token
-pub async fn request_portal_token(
+pub async fn request_verification_token(
     State(state): State<AppState>,
-    Json(req): Json<crate::command::RequestPortalTokenRequest>,
+    Json(req): Json<crate::command::RequestVerificationTokenRequest>,
 ) -> ApiResult<StreamResponse> {
     let recipient_key =
         hex_to_pubkey(&req.recipient_key).map_err(|e| bad_request(format!("Invalid recipient key: {e}")))?;

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -1023,11 +1023,65 @@ pub async fn create_verification_session(
         .await
         .map_err(|e| internal_error(format!("Failed to parse verification response: {e}")))?;
 
+    // Parse the ephemeral npub (bech32 format) into a PublicKey
+    let ephemeral_key = PublicKey::parse(&api_resp.ephemeral_npub)
+        .map_err(|e| internal_error(format!("Invalid ephemeral_npub from verification service: {e}")))?;
+
+    // Create a cashu request for the verification token
+    let expires_at = Timestamp::now_plus_seconds(300);
+    let content = CashuRequestContent {
+        mint_url: VERIFICATION_MINT_URL.to_string(),
+        unit: VERIFICATION_TICKET_UNIT.to_string(),
+        amount: VERIFICATION_TOKEN_AMOUNT,
+        request_id: Uuid::new_v4().to_string(),
+        expires_at,
+    };
+
+    let stream_id = state
+        .events
+        .new_stream("cashu_portal_token_request", None)
+        .await;
+
+    // Spawn background task to request the token (same logic as request_verification_token)
+    let sdk = state.sdk.clone();
+    let events = state.events.clone();
+    let sid = stream_id.clone();
+    tokio::spawn(async move {
+        match sdk.request_cashu(ephemeral_key, vec![], content).await {
+            Ok(Some(r)) => {
+                events
+                    .push(&sid, NotificationData::CashuResponse { status: r.status })
+                    .await;
+            }
+            Ok(None) => {
+                events
+                    .push(
+                        &sid,
+                        NotificationData::Error {
+                            reason: "No response from recipient".to_string(),
+                        },
+                    )
+                    .await;
+            }
+            Err(e) => {
+                events
+                    .push(
+                        &sid,
+                        NotificationData::Error {
+                            reason: format!("Failed to request portal token: {e}"),
+                        },
+                    )
+                    .await;
+            }
+        }
+    });
+
     Ok(ok(VerificationSessionResponse {
         session_id: api_resp.session_id,
         session_url: api_resp.session_url,
         ephemeral_npub: api_resp.ephemeral_npub,
         expires_at: api_resp.expires_at,
+        stream_id,
     }))
 }
 

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -969,9 +969,9 @@ pub async fn get_events(
 }
 
 // POST /verification/sessions
-pub async fn initiate_browser_session(
+pub async fn create_verification_session(
     State(state): State<AppState>,
-    Json(req): Json<crate::command::InitiateBrowserSessionRequest>,
+    Json(req): Json<crate::command::CreateVerificationSessionRequest>,
 ) -> ApiResult<VerificationSessionResponse> {
     let verification = state
         .settings
@@ -979,12 +979,7 @@ pub async fn initiate_browser_session(
         .as_ref()
         .ok_or_else(|| bad_request("Verification not configured — add [verification] api_key to config"))?;
 
-    let relays = req.relays.unwrap_or_else(|| {
-        vec![
-            "wss://relay.damus.io".to_string(),
-            "wss://relay.getportal.cc".to_string(),
-        ]
-    });
+    let relays = req.relays.unwrap_or_else(|| state.settings.nostr.relays.clone());
 
     #[derive(serde::Serialize)]
     struct VerifySessionRequest {

--- a/crates/portal-rest/src/main.rs
+++ b/crates/portal-rest/src/main.rs
@@ -312,7 +312,7 @@ fn build_router(state: AppState) -> Router {
         .route("/cashu/mint", post(handlers::mint_cashu))
         .route("/cashu/burn", post(handlers::burn_cashu))
         // Verification
-        .route("/verification/sessions", post(handlers::initiate_browser_session))
+        .route("/verification/sessions", post(handlers::create_verification_session))
         // Portal token (Cashu from Portal wallet)
         .route("/payments/cashu/request-token", post(handlers::request_portal_token))
         // Relays

--- a/crates/portal-rest/src/main.rs
+++ b/crates/portal-rest/src/main.rs
@@ -314,7 +314,7 @@ fn build_router(state: AppState) -> Router {
         // Verification
         .route("/verification/sessions", post(handlers::create_verification_session))
         // Portal token (Cashu from Portal wallet)
-        .route("/payments/cashu/request-token", post(handlers::request_portal_token))
+        .route("/payments/cashu/request-token", post(handlers::request_verification_token))
         // Relays
         .route("/relays", post(handlers::add_relay))
         .route("/relays", delete(handlers::remove_relay))

--- a/crates/portal-rest/src/main.rs
+++ b/crates/portal-rest/src/main.rs
@@ -313,8 +313,8 @@ fn build_router(state: AppState) -> Router {
         .route("/cashu/burn", post(handlers::burn_cashu))
         // Verification
         .route("/verification/sessions", post(handlers::create_verification_session))
-        // Portal token (Cashu from Portal wallet)
-        .route("/payments/cashu/request-token", post(handlers::request_verification_token))
+        // Verification token (Cashu from Portal wallet)
+        .route("/verification/token", post(handlers::request_verification_token))
         // Relays
         .route("/relays", post(handlers::add_relay))
         .route("/relays", delete(handlers::remove_relay))

--- a/crates/portal-rest/src/main.rs
+++ b/crates/portal-rest/src/main.rs
@@ -311,6 +311,10 @@ fn build_router(state: AppState) -> Router {
         .route("/cashu/send-direct", post(handlers::send_cashu_direct))
         .route("/cashu/mint", post(handlers::mint_cashu))
         .route("/cashu/burn", post(handlers::burn_cashu))
+        // Verification
+        .route("/verification/sessions", post(handlers::initiate_browser_session))
+        // Portal token (Cashu from Portal wallet)
+        .route("/payments/cashu/request-token", post(handlers::request_portal_token))
         // Relays
         .route("/relays", post(handlers::add_relay))
         .route("/relays", delete(handlers::remove_relay))

--- a/crates/portal-rest/src/response.rs
+++ b/crates/portal-rest/src/response.rs
@@ -129,6 +129,7 @@ pub struct VerificationSessionResponse {
     pub session_url: String,
     pub ephemeral_npub: String,
     pub expires_at: u64,
+    pub stream_id: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/portal-rest/src/response.rs
+++ b/crates/portal-rest/src/response.rs
@@ -124,6 +124,14 @@ pub struct WalletInfoResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct VerificationSessionResponse {
+    pub session_id: String,
+    pub session_url: String,
+    pub ephemeral_npub: String,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Serialize)]
 pub struct VersionResponse {
     pub version: &'static str,
     pub git_commit: &'static str,

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -24,9 +24,6 @@ import { PortalClient } from 'portal-sdk';
 const BASE_URL   = process.env.PORTAL_URL   ?? 'http://localhost:7000';
 const AUTH_TOKEN = process.env.PORTAL_TOKEN ?? 'your-secret-token';
 
-// Amount of sats to send as part of the Cashu request (matches Portal's default).
-const VERIFICATION_AMOUNT = 500;
-
 const client = new PortalClient({ baseUrl: BASE_URL, authToken: AUTH_TOKEN });
 
 async function main() {
@@ -53,11 +50,11 @@ async function main() {
   // ── Step 2: send Cashu request to the ephemeral key ─────────────────────
   // This signals to the verification worker that we're ready to receive the token.
   // The worker will hold the request until the user completes verification in the browser.
-  console.log('Sending Cashu token request to verification worker...');
+  // The token amount is set server-side (1 Portal verification ticket).
+  console.log('Sending Portal token request to verification worker...');
   const op = await client.requestPortalToken(
     session.ephemeral_npub,
     [], // no subkeys
-    VERIFICATION_AMOUNT,
   );
 
   console.log(`Stream ID: ${op.streamId}`);

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -34,16 +34,20 @@ async function main() {
   console.log('Creating age verification session...');
   const session = await client.createVerificationSession();
 
+  const sessionUrl = session.session_url.startsWith('http') ? session.session_url : `https://verify.getportal.cc${session.session_url}`;
+  const expiresAtMs = session.expires_at * 1000;
+  const timeoutMs = expiresAtMs - Date.now();
+
   console.log('');
   console.log('┌─────────────────────────────────────────────────────┐');
   console.log('│  Open this URL in a browser to complete verification │');
   console.log('├─────────────────────────────────────────────────────┤');
-  console.log(`│  ${session.session_url}`);
+  console.log(`│  ${sessionUrl}`);
   console.log('└─────────────────────────────────────────────────────┘');
   console.log('');
   console.log(`Session ID:      ${session.session_id}`);
   console.log(`Ephemeral npub:  ${session.ephemeral_npub}`);
-  console.log(`Expires at:      ${new Date(session.expires_at * 1000).toISOString()}`);
+  console.log(`Expires at:      ${new Date(expiresAtMs).toISOString()}`);
   console.log('');
 
   // ── Step 2: send Cashu request to the ephemeral key ─────────────────────
@@ -62,7 +66,7 @@ async function main() {
   // ── Step 3: wait for the result ──────────────────────────────────────────
   // This example runs as a plain CLI script (no webhook server, no auto-poller),
   // so we must explicitly poll for events until the stream reaches a terminal state.
-  const result = await client.poll(op, { intervalMs: 1000, timeoutMs: 5 * 60 * 1000 });
+  const result = await client.poll(op, { intervalMs: 1000, timeoutMs });
 
   console.log('');
   if (result.status === 'success') {

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -2,10 +2,10 @@
  * Age verification example
  *
  * Initiates a browser-based age verification session via Portal's verification
- * service. The flow is:
+ * service. A single call handles the full flow:
  *
  *   1. Create a verification session → get a `session_url` to open in the browser
- *   2. Send a Cashu token request to the session's ephemeral key
+ *   2. Automatically starts listening for the verification token
  *   3. The user completes age verification in the browser
  *   4. The verification service mints a Cashu token and sends it back
  *   5. Receiving the token = proof of age ✅
@@ -27,7 +27,7 @@ const AUTH_TOKEN = process.env.PORTAL_TOKEN ?? 'your-secret-token';
 const client = new PortalClient({ baseUrl: BASE_URL, authToken: AUTH_TOKEN });
 
 async function main() {
-  // ── Step 1: create verification session ─────────────────────────────────
+  // ── Single call: create session + start listening for token ──────────────
   console.log('Creating age verification session...');
   const session = await client.createVerificationSession();
 
@@ -44,26 +44,13 @@ async function main() {
   console.log('');
   console.log(`Session ID:      ${session.session_id}`);
   console.log(`Ephemeral npub:  ${session.ephemeral_npub}`);
+  console.log(`Stream ID:       ${session.streamId}`);
   console.log(`Expires at:      ${new Date(expiresAtMs).toISOString()}`);
   console.log('');
-
-  // ── Step 2: send Cashu request to the ephemeral key ─────────────────────
-  // This signals to the verification worker that we're ready to receive the token.
-  // The worker will hold the request until the user completes verification in the browser.
-  // The token amount is set server-side (1 Portal verification ticket).
-  console.log('Sending Portal token request to verification worker...');
-  const op = await client.requestVerificationToken(
-    session.ephemeral_npub,
-    [], // no subkeys
-  );
-
-  console.log(`Stream ID: ${op.streamId}`);
   console.log('Waiting for user to complete verification in browser...');
 
-  // ── Step 3: wait for the result ──────────────────────────────────────────
-  // This example runs as a plain CLI script (no webhook server, no auto-poller),
-  // so we must explicitly poll for events until the stream reaches a terminal state.
-  const result = await client.poll(op, { intervalMs: 1000, timeoutMs });
+  // ── Wait for the result ──────────────────────────────────────────────────
+  const result = await client.poll(session, { intervalMs: 1000, timeoutMs });
 
   console.log('');
   if (result.status === 'success') {

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -52,7 +52,7 @@ async function main() {
   // The worker will hold the request until the user completes verification in the browser.
   // The token amount is set server-side (1 Portal verification ticket).
   console.log('Sending Portal token request to verification worker...');
-  const op = await client.requestPortalToken(
+  const op = await client.requestVerificationToken(
     session.ephemeral_npub,
     [], // no subkeys
   );

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -32,7 +32,7 @@ const client = new PortalClient({ baseUrl: BASE_URL, authToken: AUTH_TOKEN });
 async function main() {
   // ── Step 1: create verification session ─────────────────────────────────
   console.log('Creating age verification session...');
-  const session = await client.initiateBrowserSession();
+  const session = await client.createVerificationSession();
 
   console.log('');
   console.log('┌─────────────────────────────────────────────────────┐');

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -1,0 +1,81 @@
+/**
+ * Age verification example
+ *
+ * Initiates a browser-based age verification session via Portal's verification
+ * service. The flow is:
+ *
+ *   1. Create a verification session → get a `session_url` to open in the browser
+ *   2. Send a Cashu token request to the session's ephemeral key
+ *   3. The user completes age verification in the browser
+ *   4. The verification service mints a Cashu token and sends it back
+ *   5. Receiving the token = proof of age ✅
+ *
+ * Usage:
+ *   PORTAL_URL=http://localhost:7000 PORTAL_TOKEN=your-token node age-verification.js
+ *
+ * Requirements:
+ *   - portal-rest must have [verification] api_key configured
+ *   - portal-rest must have a wallet configured (NWC or Breez) — needed for relay connectivity
+ */
+
+import 'dotenv/config';
+import { PortalClient } from 'portal-sdk';
+
+const BASE_URL   = process.env.PORTAL_URL   ?? 'http://localhost:7000';
+const AUTH_TOKEN = process.env.PORTAL_TOKEN ?? 'your-secret-token';
+
+// Amount of sats to send as part of the Cashu request (matches Portal's default).
+const VERIFICATION_AMOUNT = 500;
+
+const client = new PortalClient({ baseUrl: BASE_URL, authToken: AUTH_TOKEN });
+
+async function main() {
+  // ── Step 1: create verification session ─────────────────────────────────
+  console.log('Creating age verification session...');
+  const session = await client.initiateBrowserSession();
+
+  console.log('');
+  console.log('┌─────────────────────────────────────────────────────┐');
+  console.log('│  Open this URL in a browser to complete verification │');
+  console.log('├─────────────────────────────────────────────────────┤');
+  console.log(`│  ${session.session_url}`);
+  console.log('└─────────────────────────────────────────────────────┘');
+  console.log('');
+  console.log(`Session ID:      ${session.session_id}`);
+  console.log(`Ephemeral npub:  ${session.ephemeral_npub}`);
+  console.log(`Expires at:      ${new Date(session.expires_at * 1000).toISOString()}`);
+  console.log('');
+
+  // ── Step 2: send Cashu request to the ephemeral key ─────────────────────
+  // This signals to the verification worker that we're ready to receive the token.
+  // The worker will hold the request until the user completes verification in the browser.
+  console.log('Sending Cashu token request to verification worker...');
+  const op = await client.requestPortalToken(
+    session.ephemeral_npub,
+    [], // no subkeys
+    VERIFICATION_AMOUNT,
+  );
+
+  console.log(`Stream ID: ${op.streamId}`);
+  console.log('Waiting for user to complete verification in browser...');
+
+  // ── Step 3: wait for the result ──────────────────────────────────────────
+  const result = await op.done;
+
+  console.log('');
+  if (result.status === 'success') {
+    console.log('✅ Age verification successful!');
+    console.log(`   Cashu token: ${result.token}`);
+  } else if (result.status === 'rejected') {
+    console.log(`❌ Verification rejected: ${result.reason ?? '(no reason)'}`);
+  } else if (result.status === 'insufficient_funds') {
+    console.log('❌ Verification failed: insufficient funds in Portal mint');
+  } else {
+    console.log('❌ Verification failed:', result);
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message ?? err);
+  process.exit(1);
+});

--- a/examples/age-verification.js
+++ b/examples/age-verification.js
@@ -60,7 +60,9 @@ async function main() {
   console.log('Waiting for user to complete verification in browser...');
 
   // ── Step 3: wait for the result ──────────────────────────────────────────
-  const result = await op.done;
+  // This example runs as a plain CLI script (no webhook server, no auto-poller),
+  // so we must explicitly poll for events until the stream reaches a terminal state.
+  const result = await client.poll(op, { intervalMs: 1000, timeoutMs: 5 * 60 * 1000 });
 
   console.log('');
   if (result.status === 'success') {


### PR DESCRIPTION
## Age Verification for portal-rest

Adds browser-based age verification endpoints and SDK methods.

### Endpoints

#### `POST /verification/sessions` — Full web verification flow

Creates a verification session via Portal's verification service and automatically starts listening for the verification token. Returns session info + `stream_id` for polling the token result.

**Request body** (all fields optional):
```json
{ "relays": ["wss://relay.damus.io", "wss://relay.getportal.cc"] }
```

If `relays` is omitted, defaults to the relays configured in the `[nostr]` section of `config.toml`.

**Response:**
```json
{
  "session_id": "...",
  "session_url": "...",
  "ephemeral_npub": "...",
  "expires_at": 1234567890,
  "stream_id": "..."
}
```

Poll `GET /events/{stream_id}` for the `cashu_response` event containing the verification token.

Requires `[verification] api_key` in config. Returns 400 if not configured.

#### `POST /verification/token` — Request token from an already-verified user

For services that need to request a verification token from a user who already holds one (e.g. mobile app verified users). Returns a `stream_id` for polling.

**Request body:**
```json
{
  "recipient_key": "<hex pubkey>",
  "subkeys": []
}
```

---

### SDK Usage (one call)

```js
const session = await client.createVerificationSession();
console.log(`Open: ${session.session_url}`);

const result = await client.poll(session, {
  intervalMs: 1000,
  timeoutMs: 5 * 60 * 1000
});
// result.status === "success" → result.token contains the verification token
```

---

### Architecture

- Verification constants (mint URL, unit, amount) are defined server-side — not configurable by the client
- Token amount for web verification is 1 (single-use ticket), vs 500 for mobile app verification (multi-service)
- Cashu is used purely as a protocol/ticket system — tokens have no monetary value
- Shared `spawn_verification_token_request` helper eliminates duplication between the two handlers

### Changes

- **`config.rs`**: Added `VerificationSettings` struct
- **`handlers.rs`**: `create_verification_session` (full flow) + `request_verification_token` + shared `spawn_verification_token_request` helper. Verification constants extracted.
- **`response.rs`**: `VerificationSessionResponse` with `stream_id`
- **`command.rs`**: `CreateVerificationSessionRequest`, `RequestVerificationTokenRequest`
- **`main.rs`**: Routes under auth middleware
- **TS SDK**: `createVerificationSession()` returns session info + `AsyncOperation<CashuResponseStatus>` for polling. `requestVerificationToken()` for mobile flow.
- **`openapi.yaml`**: Both endpoints documented
- **`examples/age-verification.js`**: Simplified single-call example
- **`CHANGELOG.md`**: Updated

### Build

✅ `cargo build -p portal-rest` passes with no errors.