### PR TITLE
release: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## portal-rest (SDK Daemon)
 
-### Unreleased
+### [0.4.1] - 2026-04-01
 
 #### Changed
 - `GET /info` now includes `version` and `git_commit` fields (previously only in `GET /version`). `GET /version` kept for backward compatibility.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "portal-rest"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum 0.6.20",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Your backend  ←—REST API—→  sdk-daemon  ←—Nostr relays—→  Portal
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=your-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:0.4.0
+  getportal/sdk-daemon:0.4.1
 ```
 
 **2. Call the REST API**
@@ -77,8 +77,8 @@ For JavaScript/TypeScript and Java, typed SDKs are available. They wrap the same
 
 | SDK | Version | Install |
 |-----|---------|---------|
-| TypeScript / JavaScript | `0.4.0` | `npm install portal-sdk` |
-| Java | `0.4.0` | [JitPack](https://jitpack.io/#PortalTechnologiesInc/java-sdk) |
+| TypeScript / JavaScript | `0.4.1` | `npm install portal-sdk` |
+| Java | `0.4.1` | [JitPack](https://jitpack.io/#PortalTechnologiesInc/java-sdk) |
 
 The SDK `major.minor` version must match the daemon. See [Versioning & Compatibility](https://portaltechnologiesinc.github.io/lib/getting-started/versioning.html).
 

--- a/crates/portal-rest/Cargo.toml
+++ b/crates/portal-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portal-rest"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/portal-rest/clients/ts/package.json
+++ b/crates/portal-rest/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Official TypeScript/JavaScript client for the Portal REST API — Nostr auth, Lightning payments, JWT, Cashu, profiles, polling",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/crates/portal-rest/openapi.yaml
+++ b/crates/portal-rest/openapi.yaml
@@ -25,7 +25,7 @@ info:
     If `webhook_url` is configured, server-initiated events are also POSTed to that URL.
     The `X-Portal-Signature` header contains an HMAC-SHA256 hex digest of the body,
     computed with the `webhook_secret`.
-  version: "0.4.0"
+  version: "0.4.1"
   contact:
     name: Portal Technologies Inc.
     url: https://getportal.cc

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -90,7 +90,7 @@ Convert nsec to hex: `nak decode nsec1...`
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=my-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:0.4.0
+  getportal/sdk-daemon:0.4.1
 ```
 
 Or use a `.env` file: `docker run --env-file .env ...`. Don't commit `.env`.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -10,7 +10,7 @@ You need a Nostr private key (hex) and a secret auth token. Then:
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=my-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:0.4.0
+  getportal/sdk-daemon:0.4.1
 ```
 
 Check it's running:
@@ -57,7 +57,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.0'
+    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.1'
 }
 ```
 
@@ -71,7 +71,7 @@ dependencies {
 <dependency>
     <groupId>com.github.PortalTechnologiesInc</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
 </dependency>
 ```
 

--- a/docs/getting-started/versioning.md
+++ b/docs/getting-started/versioning.md
@@ -32,21 +32,21 @@ When a new `major.minor` version is released:
 2. Update the Docker image tag to the matching version.
 3. Check the [CHANGELOG](../../CHANGELOG.md) for breaking changes.
 
-**Example — upgrading to 0.4.0:**
+**Example — upgrading to 0.4.1:**
 
 ```bash
 # Docker
-docker pull getportal/sdk-daemon:0.4.0
+docker pull getportal/sdk-daemon:0.4.1
 ```
 
 ```bash
 # npm
-npm install portal-sdk@0.4.0
+npm install portal-sdk@0.4.1
 ```
 
 ```groovy
 // Gradle
-implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.0'
+implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.1'
 ```
 
 ## Current versions

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -72,7 +72,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.0'
+    implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.1'
 }
 ```
 
@@ -86,7 +86,7 @@ dependencies {
 <dependency>
     <groupId>com.github.PortalTechnologiesInc</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Release 0.4.1

### What's new
- **Age verification** — `POST /verification/sessions` (full web flow) + `POST /verification/token` (mobile/cross-service)
- **NIP-05 auto-registration** — automatic `@getportal.cc` registration at startup
- **`GET /info`** now includes `version` and `git_commit` fields

### Version bumps
- `crates/portal-rest/Cargo.toml` → `0.4.1`
- `crates/portal-rest/clients/ts/package.json` → `0.4.1`
- `crates/portal-rest/openapi.yaml` → `0.4.1`
- README, docs, installation guides updated

### Changelog
`Unreleased` → `[0.4.1] - 2026-04-01`

### Build
✅ `cargo build -p portal-rest` passes