### PR TITLE
docs: clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,72 @@
+<div align="center">
+
 # Portal
 
-[![Documentation](https://img.shields.io/badge/docs-portaltechnologiesinc.github.io-blue)](https://portaltechnologiesinc.github.io/lib/)
+**Identity and payments for Bitcoin-native applications.**
+
+No accounts. No KYC. No payment processor.
+
+[![Docs](https://img.shields.io/badge/docs-portal-blue)](https://portaltechnologiesinc.github.io/lib/)
+[![Docker](https://img.shields.io/docker/v/getportal/sdk-daemon?label=docker&color=blue)](https://hub.docker.com/r/getportal/sdk-daemon)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)
-[![Docker](https://img.shields.io/docker/v/getportal/sdk-daemon?label=sdk-daemon&color=blue)](https://hub.docker.com/r/getportal/sdk-daemon)
 
-**Portal is the identity and payment layer for Bitcoin-native applications — no accounts, no KYC, no payment processor.**
+</div>
 
-Users interact through the Portal mobile app using their Nostr identity. You run a single Docker container and call its REST API from any language.
+## About
 
----
-
-## How it works
+Portal lets users authenticate and pay using their Nostr identity through the Portal mobile app. You run a single Docker container (`sdk-daemon`) and call its REST API from any language.
 
 ```
-Your backend  ←—REST API—→  sdk-daemon  ←—Nostr relays—→  Portal app (user's phone)
+Your backend  ←— REST API —→  sdk-daemon  ←— Nostr —→  Portal app
 ```
 
-1. Your backend asks sdk-daemon for a handshake URL → show it as a QR code
-2. User scans with Portal app → you receive their Nostr public key
-3. Your backend requests a payment (sats or fiat) → user approves in app → Lightning settlement
+## Features
 
----
+- **Authentication** — passwordless login via Nostr
+- **Age verification** — browser-based identity verification with cryptographic proof
+- **Payments** — single, recurring, invoice-based; BTC or fiat
+- **JWTs** — signed by the user's Nostr key
+- **Cashu tokens** — mint, burn, and transfer ecash
+- **Wallets** — NWC or Breez for outbound payments
 
 ## Quick start
 
-**1. Run sdk-daemon**
-
 ```bash
 docker run -d -p 3000:3000 \
-  -e PORTAL__AUTH__AUTH_TOKEN=your-secret-token \
-  -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
+  -e PORTAL__AUTH__AUTH_TOKEN=$(openssl rand -hex 32) \
+  -e PORTAL__NOSTR__PRIVATE_KEY=<your-64-char-hex-key> \
   getportal/sdk-daemon:0.4.1
 ```
 
-**2. Call the REST API**
+Then follow the [Quick Start guide](https://portaltechnologiesinc.github.io/lib/getting-started/quick-start.html) or jump to the [REST API reference](https://portaltechnologiesinc.github.io/lib/sdk/rest-api.html).
 
-```bash
-# Get a handshake URL — show it to the user as a QR code
-curl -s -X POST http://localhost:3000/key-handshake \
-  -H "Authorization: Bearer your-secret-token" \
-  -H "Content-Type: application/json" \
-  -d '{}' | jq .
+## SDKs
 
-# → { "stream_id": "abc123", "url": "nostr+walletconnect://..." }
-
-# Poll for the user's public key (repeat until events arrive)
-curl -s "http://localhost:3000/events/abc123?after=0" \
-  -H "Authorization: Bearer your-secret-token" | jq .
-```
-
-Any language works — Python, Go, Ruby, PHP, Java, TypeScript. No SDK required.
-
----
-
-## What you can do
-
-- **Authenticate users** — passwordless login via Nostr identity
-- **Age verification** — browser-based identity verification with cryptographic proof ([guide](https://portaltechnologiesinc.github.io/lib/guides/age-verification.html))
-- **Request payments** — single, recurring, or invoice-based; BTC (sats) or fiat (EUR, USD, and [more](https://portaltechnologiesinc.github.io/lib/sdk/api-reference.html))
-- **Issue JWTs** — signed by the user's Nostr key, verifiable server-side
-- **Cashu tokens** — mint, burn, and transfer ecash
-- **NWC wallet** — connect any NWC-compatible wallet for outbound payments
-
----
+| Language | Install |
+|----------|---------|
+| TypeScript / JS | `npm install portal-sdk` |
+| Java | [JitPack](https://jitpack.io/#PortalTechnologiesInc/java-sdk) |
+| Any language | [REST API](https://portaltechnologiesinc.github.io/lib/sdk/rest-api.html) — no SDK needed |
 
 ## Documentation
 
-Full docs at **[portaltechnologiesinc.github.io/lib](https://portaltechnologiesinc.github.io/lib/)** — REST API reference, curl examples, guides for authentication, payments, Cashu, JWT, Docker deployment, and more.
+Full docs: **[portaltechnologiesinc.github.io/lib](https://portaltechnologiesinc.github.io/lib/)**
 
----
+Guides: [Authentication](https://portaltechnologiesinc.github.io/lib/guides/authentication.html) · [Age Verification](https://portaltechnologiesinc.github.io/lib/guides/age-verification.html) · [Payments](https://portaltechnologiesinc.github.io/lib/guides/single-payments.html) · [Cashu](https://portaltechnologiesinc.github.io/lib/guides/cashu-tokens.html) · [JWT](https://portaltechnologiesinc.github.io/lib/guides/jwt-tokens.html) · [Docker](https://portaltechnologiesinc.github.io/lib/getting-started/docker-deployment.html)
 
-## Official SDKs
+## Repository structure
 
-For JavaScript/TypeScript and Java, typed SDKs are available. They wrap the same REST API with auto-polling, webhook handling, and typed responses.
-
-| SDK | Version | Install |
-|-----|---------|---------|
-| TypeScript / JavaScript | `0.4.1` | `npm install portal-sdk` |
-| Java | `0.4.1` | [JitPack](https://jitpack.io/#PortalTechnologiesInc/java-sdk) |
-
-The SDK `major.minor` version must match the daemon. See [Versioning & Compatibility](https://portaltechnologiesinc.github.io/lib/getting-started/versioning.html).
-
----
-
-## This repository
-
-| Package | Description |
-|---------|-------------|
-| `portal-rest` | SDK Daemon — REST API server |
-| `portal` | Core Nostr protocol and conversation logic |
+| Crate | Description |
+|-------|-------------|
+| `portal-rest` | REST API daemon |
+| `portal` | Core protocol and conversation logic |
 | `portal-app` | App runtime and wallet integration |
 | `portal-wallet` | Wallet backends (NWC, Breez) |
 | `portal-rates` | Fiat/BTC exchange rates |
-| `clients/ts` | TypeScript SDK source |
-| `portal-cli` | CLI tools for development and testing |
+| `clients/ts` | TypeScript SDK |
+| `portal-cli` | Dev/testing CLI tools |
 
----
+## License
 
-**License:** MIT · [Java SDK](https://github.com/PortalTechnologiesInc/java-sdk) · [Demo](https://github.com/PortalTechnologiesInc/portal-demo)
+MIT — see [LICENSE](LICENSE)


### PR DESCRIPTION
Shorter, cleaner README. Moves heavy code examples to docs, keeps only a Docker one-liner. 39 lines added, 68 removed.

**Before:** tutorial-style wall of text with inline curl examples, ASCII diagrams, SDK version tables
**After:** centered header, short feature list, one Docker command, links to docs for everything else