### PR TITLE
feat(portal): relay send outcome feedback via EventSendResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## portal-rest (SDK Daemon)
 
+### Unreleased
+
+#### Added
+- `MessageRouter` now exposes `SendOutcome` / `EventSendResult` from the underlying `portal` crate, giving relay delivery feedback per event. Not yet surfaced on the REST API; wiring will follow in a future release (#85)
+
+---
+
 ### [0.4.1] - 2026-04-01
 
 #### Changed
@@ -90,6 +97,9 @@ First release — Docker image available at [`getportal/sdk-daemon`](https://hub
 ## portal-app (App Library)
 
 ### Unreleased
+
+#### Added
+- `MessageRouter::add_conversation`, `add_conversation_with_relays` and `add_and_subscribe` now return `Vec<EventSendResult>` alongside their existing values, pairing each broadcasted Nostr event ID with a `SendOutcome` (`Delivered` / `Queued` / `Dropped`). Callers can now detect when a command is silently queued because no relay is connected (#85). Existing mobile app behavior is preserved — outcomes are currently ignored, ready to be wired into the UI when needed.
 
 #### Changed
 - `register_nip05()` now delegates to `portal::register_nip05()` (moved to `portal` crate). UniFFI bindings unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Unreleased
 
 #### Added
-- `MessageRouter` now exposes `SendOutcome` / `EventSendResult` from the underlying `portal` crate, giving relay delivery feedback per event. Not yet surfaced on the REST API; wiring will follow in a future release (#85)
+- `MessageRouter` now exposes `SendOutcome` / `EventSendResult` from the underlying `portal` crate, giving relay delivery feedback per event. `SendOutcome::Delivered { relays }` includes the URLs of relays that accepted the event. Not yet surfaced on the REST API; wiring will follow in a future release (#85)
 
 ---
 
@@ -99,7 +99,7 @@ First release — Docker image available at [`getportal/sdk-daemon`](https://hub
 ### Unreleased
 
 #### Added
-- `MessageRouter::add_conversation`, `add_conversation_with_relays` and `add_and_subscribe` now return `Vec<EventSendResult>` alongside their existing values, pairing each broadcasted Nostr event ID with a `SendOutcome` (`Delivered` / `Queued` / `Dropped`). Callers can now detect when a command is silently queued because no relay is connected (#85). Existing mobile app behavior is preserved — outcomes are currently ignored, ready to be wired into the UI when needed.
+- `MessageRouter::add_conversation`, `add_conversation_with_relays` and `add_and_subscribe` now return `Vec<EventSendResult>` alongside their existing values, pairing each broadcasted Nostr event ID with a `SendOutcome`. `Delivered { relays }` includes the list of relay URLs that accepted the event; `Queued` means no relay was available (event queued for retry); `Dropped` means the queue was full. Callers can now detect when a command is silently queued because no relay is connected (#85). Existing mobile app behavior is preserved — outcomes are currently ignored, ready to be wired into the UI when needed.
 
 #### Changed
 - `register_nip05()` now delegates to `portal::register_nip05()` (moved to `portal` crate). UniFFI bindings unchanged.

--- a/crates/portal-app/src/lib.rs
+++ b/crates/portal-app/src/lib.rs
@@ -414,48 +414,48 @@ impl PortalApp {
             router.add_relay(relay.clone(), false).await?;
         }
 
-        let auth_challenge_rx: NotificationStream<AuthChallengeEvent> = router
+        let (auth_challenge_rx, _outcomes): (NotificationStream<AuthChallengeEvent>, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 AuthChallengeListenerConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
             )))
             .await?;
-        let payment_request_rx: NotificationStream<PaymentRequestEvent> =
+        let (payment_request_rx, _outcomes): (NotificationStream<PaymentRequestEvent>, _) =
             router
                 .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                     PaymentRequestListenerConversation::new(router.keypair().public_key()),
                     router.keypair().subkey_proof().cloned(),
                 )))
                 .await?;
-        let closed_recurring_payment_rx: NotificationStream<
+        let (closed_recurring_payment_rx, _outcomes): (NotificationStream<
             portal::protocol::model::payment::CloseRecurringPaymentResponse,
-        > = router
+        >, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 CloseRecurringPaymentReceiverConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
             )))
             .await?;
-        let invoice_request_rx: NotificationStream<
+        let (invoice_request_rx, _outcomes): (NotificationStream<
             portal::protocol::model::payment::InvoiceRequestContentWithKey,
-        > = router
+        >, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 InvoiceReceiverConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
             )))
             .await?;
-        let cashu_request_rx: NotificationStream<CashuRequestContentWithKey> = router
+        let (cashu_request_rx, _outcomes): (NotificationStream<CashuRequestContentWithKey>, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 CashuRequestReceiverConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
             )))
             .await?;
-        let cashu_direct_rx: NotificationStream<CashuDirectContentWithKey> = router
+        let (cashu_direct_rx, _outcomes): (NotificationStream<CashuDirectContentWithKey>, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 CashuDirectReceiverConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
             )))
             .await?;
-        let nip46_rx: NotificationStream<Nip46Request> = router
+        let (nip46_rx, _outcomes): (NotificationStream<Nip46Request>, _) = router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 Nip46RequestListenerConversation::new(router.keypair().public_key()),
                 router.keypair().subkey_proof().cloned(),
@@ -554,7 +554,7 @@ impl PortalApp {
             }
         }
 
-        let _id = self
+        let (_id, _outcomes) = self
             .router
             .add_conversation_with_relays(
                 Box::new(OneShotSenderAdapter::new_with_user(
@@ -606,7 +606,7 @@ impl PortalApp {
             self.router.keypair().subkey_proof().cloned(),
             status,
         );
-        self.router
+        let _ = self.router
             .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
                 recipient.into(),
                 vec![],
@@ -697,7 +697,7 @@ impl PortalApp {
 
     pub async fn fetch_profile(&self, pubkey: PublicKey) -> Result<Option<Profile>, AppError> {
         let conv = FetchProfileInfoConversation::new(pubkey.into());
-        let mut notification: NotificationStream<Option<portal::conversation::profile::Profile>> =
+        let (mut notification, _outcomes): (NotificationStream<Option<portal::conversation::profile::Profile>>, _) =
             self.router.add_and_subscribe(Box::new(conv)).await?;
         let metadata = notification
             .next()
@@ -733,8 +733,7 @@ impl PortalApp {
         }
 
         let conv = SetProfileConversation::new(profile);
-        let _ = self
-            .router
+        let _ = self.router
             .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
                 self.router.keypair().public_key().into(),
                 vec![],
@@ -765,7 +764,7 @@ impl PortalApp {
         };
 
         let conv = CloseRecurringPaymentConversation::new(content);
-        self.router
+        let _ = self.router
             .add_conversation(Box::new(MultiKeySenderAdapter::new_with_user(
                 service_key.into(),
                 vec![],
@@ -916,7 +915,7 @@ impl PortalApp {
             nostr_connect_message.id().to_string(),
             conversation_result,
         );
-        router
+        let _ = router
             .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
                 event.nostr_client_pubkey.into(),
                 vec![],
@@ -983,7 +982,7 @@ impl PortalApp {
 
         let conv = InvoiceSenderConversation::new(invoice_response);
 
-        self.router
+        let _ = self.router
             .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
                 recipient,
                 vec![],
@@ -1013,7 +1012,7 @@ impl PortalApp {
             self.router.keypair().subkey_proof().cloned(),
             content,
         );
-        let mut rx: NotificationStream<portal::protocol::model::payment::InvoiceResponse> = self
+        let (mut rx, _outcomes): (NotificationStream<portal::protocol::model::payment::InvoiceResponse>, _) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 recipient.into(),
@@ -1049,7 +1048,7 @@ impl PortalApp {
         let recipient = request.recipient.clone().into();
         let response = CashuResponseContent { request, status };
         let conv = CashuResponseSenderConversation::new(response);
-        self.router
+        let _ = self.router
             .add_conversation(Box::new(OneShotSenderAdapter::new_with_user(
                 recipient,
                 vec![],
@@ -1088,7 +1087,7 @@ impl PortalApp {
         )
         .map_err(AppError::RequestSinglePaymentError)?;
 
-        self.router
+        let _ = self.router
             .add_conversation(Box::new(MultiKeySenderAdapter::new_with_user(
                 receiver_pubkey,
                 vec![],

--- a/crates/portal-sdk/src/lib.rs
+++ b/crates/portal-sdk/src/lib.rs
@@ -89,7 +89,7 @@ impl PortalSDK {
             self.router.keypair().public_key(),
             token.clone(),
         );
-        let event = self
+        let (event, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 inner,
@@ -127,7 +127,7 @@ impl PortalSDK {
             self.router.keypair().subkey_proof().cloned(),
         );
 
-        let mut event = self
+        let (mut event, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 main_key, subkeys, conv,
@@ -149,7 +149,7 @@ impl PortalSDK {
         )
         .map_err(PortalSDKError::ProtocolError)?;
 
-        let mut event = self
+        let (mut event, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 main_key, subkeys, conv,
@@ -171,7 +171,7 @@ impl PortalSDK {
         )
         .map_err(PortalSDKError::ProtocolError)?;
 
-        let event = self
+        let (event, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 main_key, subkeys, conv,
@@ -185,7 +185,7 @@ impl PortalSDK {
         main_key: PublicKey,
     ) -> Result<Option<Profile>, PortalSDKError> {
         let conv = FetchProfileInfoConversation::new(main_key);
-        let mut event = self.router.add_and_subscribe(Box::new(conv)).await?;
+        let (mut event, _outcomes) = self.router.add_and_subscribe(Box::new(conv)).await?;
         let profile: Option<Profile> = event.next().await.ok_or(PortalSDKError::Timeout)??;
 
         if let Some(mut profile) = profile {
@@ -224,7 +224,7 @@ impl PortalSDK {
     ) -> Result<NotificationStream<CloseRecurringPaymentResponse>, PortalSDKError> {
         let inner =
             CloseRecurringPaymentReceiverConversation::new(self.router.keypair().public_key());
-        let event = self
+        let (event, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
                 inner,
@@ -266,7 +266,7 @@ impl PortalSDK {
             self.router.keypair().subkey_proof().cloned(),
             content,
         );
-        let mut rx = self
+        let (mut rx, _outcomes) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 recipient, subkeys, conv,
@@ -312,7 +312,7 @@ impl PortalSDK {
             self.router.keypair().subkey_proof().cloned(),
             content,
         );
-        let mut rx: NotificationStream<CashuResponseContent> = self
+        let (mut rx, _outcomes): (NotificationStream<CashuResponseContent>, _) = self
             .router
             .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
                 main_key, subkeys, conv,

--- a/crates/portal/src/bin/test_app.rs
+++ b/crates/portal/src/bin/test_app.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // auth init sent
 
     let inner = AuthChallengeListenerConversation::new(router.keypair().public_key());
-    let mut rx: portal::router::NotificationStream<portal::conversation::app::auth::AuthChallengeEvent> = router
+    let (mut rx, _outcomes): (portal::router::NotificationStream<portal::conversation::app::auth::AuthChallengeEvent>, _) = router
         .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
             inner,
             router.keypair().subkey_proof().cloned(),

--- a/crates/portal/src/bin/test_sdk.rs
+++ b/crates/portal/src/bin/test_sdk.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Auth init URL: {}", url);
 
     let inner = KeyHandshakeReceiverConversation::new(router.keypair().public_key(), token);
-    let id = router
+    let (id, _outcomes) = router
         .add_conversation(Box::new(MultiKeyListenerAdapter::new(
             inner,
             router.keypair().subkey_proof().cloned(),
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         router.keypair().public_key(),
         router.keypair().subkey_proof().cloned(),
     );
-    let id = router
+    let (id, _outcomes) = router
         .add_conversation(Box::new(MultiKeySenderAdapter::new_with_user(
             event.main_key,
             vec![],

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -24,6 +24,17 @@ use crate::{
 /// Max events waiting for relay retry; avoids unbounded memory if a relay stays down.
 const MAX_PENDING_RELAY_EVENTS: usize = 512;
 
+/// Outcome of attempting to send an event to relays.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// At least one relay received the event.
+    Delivered,
+    /// No relay was available; the event has been queued for retry.
+    Queued,
+    /// The pending queue was full and the event was dropped.
+    Dropped,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum MessageRouterActorError {
     #[error("Channel error: {0}")]
@@ -753,8 +764,11 @@ impl MessageRouterActorState {
         };
 
         log::debug!("Processing response for conversation: {}", conversation_id);
-        self.process_response(channel, &conversation_id, response, subscription_id)
+        let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
+        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
+            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
+        }
 
         Ok(())
     }
@@ -765,7 +779,7 @@ impl MessageRouterActorState {
         id: &PortalConversationId,
         response: Response,
         subscription_id: PortalSubscriptionId,
-    ) -> Result<(), ConversationError>
+    ) -> Result<Vec<SendOutcome>, ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -884,14 +898,17 @@ impl MessageRouterActorState {
         }
 
         // check if Response has selected relays
+        let mut outcomes = Vec::new();
         if let Some(selected_relays) = selected_relays_optional {
             for event in events_to_broadcast {
-                self.queue_event(channel, event, Some(selected_relays.clone()))
+                let outcome = self.queue_event(channel, event, Some(selected_relays.clone()))
                     .await?;
+                outcomes.push(outcome);
             }
         } else {
             for event in events_to_broadcast {
-                self.queue_event(channel, event, None).await?;
+                let outcome = self.queue_event(channel, event, None).await?;
+                outcomes.push(outcome);
             }
 
             // TODO: wait for confirmation from relays
@@ -902,7 +919,7 @@ impl MessageRouterActorState {
             self.cleanup_conversation(channel, id).await?;
         }
 
-        Ok(())
+        Ok(outcomes)
     }
 
     async fn queue_event<C: Channel>(
@@ -910,42 +927,58 @@ impl MessageRouterActorState {
         channel: &Arc<C>,
         event: Event,
         relays: Option<HashSet<String>>,
-    ) -> Result<(), ConversationError>
+    ) -> Result<SendOutcome, ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
-        let failed = if let Some(ref target_relays) = relays {
-            channel
+        let (failed, all_targeted) = if let Some(ref target_relays) = relays {
+            let num_targets = target_relays.len();
+            let failed_set = channel
                 .broadcast_to(target_relays.clone(), event.clone())
                 .await
-                .map_err(|e| ConversationError::Inner(Box::new(e)))?
+                .map_err(|e| ConversationError::Inner(Box::new(e)))?;
+            (failed_set, num_targets)
         } else {
-            channel
+            let failed_set = channel
                 .broadcast(event.clone())
                 .await
-                .map_err(|e| ConversationError::Inner(Box::new(e)))?
+                .map_err(|e| ConversationError::Inner(Box::new(e)))?;
+            // broadcast targets all known relays; when all fail,
+            // failed.len() == total relay count, so the comparison below holds.
+            let n = failed_set.len();
+            (failed_set, n)
         };
 
-        if !failed.is_empty() {
-            log::warn!(
-                "Event {:?} failed on {} relay(s), queuing for retry: {:?}",
-                event.id,
-                failed.len(),
-                failed
-            );
-            // Queue only for the failed relays (surgical retry), but keep memory bounded.
-            if self.pending_events.len() >= MAX_PENDING_RELAY_EVENTS {
-                log::error!(
-                    "pending relay event queue is full (max {}), dropping retry for event {:?}",
-                    MAX_PENDING_RELAY_EVENTS,
-                    event.id
-                );
-            } else {
-                self.pending_events.push((event, Some(failed)));
-            }
+        if failed.is_empty() {
+            return Ok(SendOutcome::Delivered);
         }
 
-        Ok(())
+        log::warn!(
+            "Event {:?} failed on {} of {} relay(s), queuing for retry: {:?}",
+            event.id,
+            failed.len(),
+            all_targeted,
+            failed
+        );
+
+        // Queue only for the failed relays (surgical retry), but keep memory bounded.
+        if self.pending_events.len() >= MAX_PENDING_RELAY_EVENTS {
+            log::error!(
+                "pending relay event queue is full (max {}), dropping retry for event {:?}",
+                MAX_PENDING_RELAY_EVENTS,
+                event.id
+            );
+            return Ok(SendOutcome::Dropped);
+        }
+
+        self.pending_events.push((event, Some(failed.clone())));
+
+        if failed.len() >= all_targeted {
+            Ok(SendOutcome::Queued)
+        } else {
+            // At least one relay received the event
+            Ok(SendOutcome::Delivered)
+        }
     }
 
     /// Attempt to flush any events that were queued while the relay was disconnected.
@@ -1083,8 +1116,11 @@ impl MessageRouterActorState {
 
         let subscription_id = PortalSubscriptionId::generate();
         let response = self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, None, None)?;
-        self.process_response(channel, &conversation_id, response, subscription_id)
+        let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
+        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
+            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
+        }
 
         Ok(conversation_id)
     }
@@ -1103,8 +1139,11 @@ impl MessageRouterActorState {
         let subscription_id = PortalSubscriptionId::generate();
         let response =
             self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, Some(relays), None)?;
-        self.process_response(channel, &conversation_id, response, subscription_id)
+        let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
+        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
+            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
+        }
 
         Ok(conversation_id)
     }
@@ -1174,8 +1213,11 @@ impl MessageRouterActorState {
         // Now add the conversation
         let subscription_id = PortalSubscriptionId::generate();
         let response = self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, None, Some(tx))?;
-        self.process_response(channel, &conversation_id, response, subscription_id)
+        let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
+        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
+            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
+        }
 
         Ok(rx)
     }

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -948,14 +948,11 @@ impl MessageRouterActorState {
                 .map_err(|e| ConversationError::Inner(Box::new(e)))?;
             (failed_set, num_targets)
         } else {
-            let failed_set = channel
+            let (failed_set, total) = channel
                 .broadcast(event.clone())
                 .await
                 .map_err(|e| ConversationError::Inner(Box::new(e)))?;
-            // broadcast targets all known relays; when all fail,
-            // failed.len() == total relay count, so the comparison below holds.
-            let n = failed_set.len();
-            (failed_set, n)
+            (failed_set, total)
         };
 
         if failed.is_empty() {
@@ -1043,6 +1040,7 @@ impl MessageRouterActorState {
                 channel
                     .broadcast(event.clone())
                     .await
+                    .map(|(failed, _total)| failed)
                     .map_err(|e| ConversationError::Inner(Box::new(e)))
             };
 

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -52,12 +52,12 @@ pub enum MessageRouterActorMessage {
     Shutdown(oneshot::Sender<Result<(), ConversationError>>),
     AddConversation(
         ConversationBox,
-        oneshot::Sender<Result<PortalConversationId, ConversationError>>,
+        oneshot::Sender<Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>>,
     ),
     AddConversationWithRelays(
         ConversationBox,
         Vec<String>,
-        oneshot::Sender<Result<PortalConversationId, ConversationError>>,
+        oneshot::Sender<Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>>,
     ),
     SubscribeToServiceRequest(
         PortalConversationId,
@@ -65,7 +65,7 @@ pub enum MessageRouterActorMessage {
     ),
     AddAndSubscribe(
         ConversationBox,
-        oneshot::Sender<Result<NotificationStream<serde_json::Value>, ConversationError>>,
+        oneshot::Sender<Result<(NotificationStream<serde_json::Value>, Vec<SendOutcome>), ConversationError>>,
     ),
     Ping(oneshot::Sender<()>),
 
@@ -286,7 +286,7 @@ where
     pub async fn add_conversation(
         &self,
         conversation: ConversationBox,
-    ) -> Result<PortalConversationId, MessageRouterActorError> {
+    ) -> Result<(PortalConversationId, Vec<SendOutcome>), MessageRouterActorError> {
         self.ping().await?;
         self.ping().await?;
 
@@ -301,7 +301,7 @@ where
         &self,
         conversation: ConversationBox,
         relays: Vec<String>,
-    ) -> Result<PortalConversationId, MessageRouterActorError> {
+    ) -> Result<(PortalConversationId, Vec<SendOutcome>), MessageRouterActorError> {
         let (tx, rx) = oneshot::channel();
         self.send_message(MessageRouterActorMessage::AddConversationWithRelays(
             conversation,
@@ -364,19 +364,19 @@ where
     pub async fn add_and_subscribe<T: DeserializeOwned + Serialize>(
         &self,
         conversation: ConversationBox,
-    ) -> Result<NotificationStream<T>, MessageRouterActorError> {
-        let raw_stream = self.add_and_subscribe_raw(conversation).await?;
+    ) -> Result<(NotificationStream<T>, Vec<SendOutcome>), MessageRouterActorError> {
+        let (raw_stream, outcomes) = self.add_and_subscribe_raw(conversation).await?;
         let NotificationStream { stream } = raw_stream;
         let typed_stream =
             stream.map(|result| result.and_then(|value| serde_json::from_value(value)));
-        Ok(NotificationStream::new(typed_stream))
+        Ok((NotificationStream::new(typed_stream), outcomes))
     }
 
     /// Adds a conversation and subscribes to its notifications in a single operation (raw Value).
     async fn add_and_subscribe_raw(
         &self,
         conversation: ConversationBox,
-    ) -> Result<NotificationStream<serde_json::Value>, MessageRouterActorError> {
+    ) -> Result<(NotificationStream<serde_json::Value>, Vec<SendOutcome>), MessageRouterActorError> {
         let (tx, rx) = oneshot::channel();
         self.send_message(MessageRouterActorMessage::AddAndSubscribe(conversation, tx))
             .await?;
@@ -1108,7 +1108,7 @@ impl MessageRouterActorState {
         &mut self,
         channel: &Arc<C>,
         conversation: ConversationBox,
-    ) -> Result<PortalConversationId, ConversationError>
+    ) -> Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -1118,11 +1118,8 @@ impl MessageRouterActorState {
         let response = self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, None, None)?;
         let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
-        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
-            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
-        }
 
-        Ok(conversation_id)
+        Ok((conversation_id, outcomes))
     }
 
     pub async fn add_conversation_with_relays<C: Channel>(
@@ -1130,7 +1127,7 @@ impl MessageRouterActorState {
         channel: &Arc<C>,
         conversation: ConversationBox,
         relays: Vec<String>,
-    ) -> Result<PortalConversationId, ConversationError>
+    ) -> Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -1141,11 +1138,8 @@ impl MessageRouterActorState {
             self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, Some(relays), None)?;
         let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
-        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
-            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
-        }
 
-        Ok(conversation_id)
+        Ok((conversation_id, outcomes))
     }
 
     /// Subscribes to notifications from a conversation.
@@ -1197,7 +1191,7 @@ impl MessageRouterActorState {
         &mut self,
         channel: &Arc<C>,
         conversation: ConversationBox,
-    ) -> Result<NotificationStream<T>, ConversationError>
+    ) -> Result<(NotificationStream<T>, Vec<SendOutcome>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -1215,11 +1209,8 @@ impl MessageRouterActorState {
         let response = self.internal_add_with_id(&conversation_id, subscription_id.clone(), conversation, None, Some(tx))?;
         let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
-        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
-            log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
-        }
 
-        Ok(rx)
+        Ok((rx, outcomes))
     }
 }
 

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -35,6 +35,13 @@ pub enum SendOutcome {
     Dropped,
 }
 
+/// Result of sending a single Nostr event, pairing the event ID with its delivery outcome.
+#[derive(Debug, Clone)]
+pub struct EventSendResult {
+    pub event_id: nostr::EventId,
+    pub outcome: SendOutcome,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum MessageRouterActorError {
     #[error("Channel error: {0}")]
@@ -52,12 +59,12 @@ pub enum MessageRouterActorMessage {
     Shutdown(oneshot::Sender<Result<(), ConversationError>>),
     AddConversation(
         ConversationBox,
-        oneshot::Sender<Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>>,
+        oneshot::Sender<Result<(PortalConversationId, Vec<EventSendResult>), ConversationError>>,
     ),
     AddConversationWithRelays(
         ConversationBox,
         Vec<String>,
-        oneshot::Sender<Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>>,
+        oneshot::Sender<Result<(PortalConversationId, Vec<EventSendResult>), ConversationError>>,
     ),
     SubscribeToServiceRequest(
         PortalConversationId,
@@ -65,7 +72,7 @@ pub enum MessageRouterActorMessage {
     ),
     AddAndSubscribe(
         ConversationBox,
-        oneshot::Sender<Result<(NotificationStream<serde_json::Value>, Vec<SendOutcome>), ConversationError>>,
+        oneshot::Sender<Result<(NotificationStream<serde_json::Value>, Vec<EventSendResult>), ConversationError>>,
     ),
     Ping(oneshot::Sender<()>),
 
@@ -286,7 +293,7 @@ where
     pub async fn add_conversation(
         &self,
         conversation: ConversationBox,
-    ) -> Result<(PortalConversationId, Vec<SendOutcome>), MessageRouterActorError> {
+    ) -> Result<(PortalConversationId, Vec<EventSendResult>), MessageRouterActorError> {
         self.ping().await?;
         self.ping().await?;
 
@@ -301,7 +308,7 @@ where
         &self,
         conversation: ConversationBox,
         relays: Vec<String>,
-    ) -> Result<(PortalConversationId, Vec<SendOutcome>), MessageRouterActorError> {
+    ) -> Result<(PortalConversationId, Vec<EventSendResult>), MessageRouterActorError> {
         let (tx, rx) = oneshot::channel();
         self.send_message(MessageRouterActorMessage::AddConversationWithRelays(
             conversation,
@@ -364,7 +371,7 @@ where
     pub async fn add_and_subscribe<T: DeserializeOwned + Serialize>(
         &self,
         conversation: ConversationBox,
-    ) -> Result<(NotificationStream<T>, Vec<SendOutcome>), MessageRouterActorError> {
+    ) -> Result<(NotificationStream<T>, Vec<EventSendResult>), MessageRouterActorError> {
         let (raw_stream, outcomes) = self.add_and_subscribe_raw(conversation).await?;
         let NotificationStream { stream } = raw_stream;
         let typed_stream =
@@ -376,7 +383,7 @@ where
     async fn add_and_subscribe_raw(
         &self,
         conversation: ConversationBox,
-    ) -> Result<(NotificationStream<serde_json::Value>, Vec<SendOutcome>), MessageRouterActorError> {
+    ) -> Result<(NotificationStream<serde_json::Value>, Vec<EventSendResult>), MessageRouterActorError> {
         let (tx, rx) = oneshot::channel();
         self.send_message(MessageRouterActorMessage::AddAndSubscribe(conversation, tx))
             .await?;
@@ -766,7 +773,7 @@ impl MessageRouterActorState {
         log::debug!("Processing response for conversation: {}", conversation_id);
         let outcomes = self.process_response(channel, &conversation_id, response, subscription_id)
             .await?;
-        if outcomes.iter().any(|o| *o == SendOutcome::Queued) {
+        if outcomes.iter().any(|r| r.outcome == SendOutcome::Queued) {
             log::warn!("One or more events for conversation {} were queued (no relay connected)", conversation_id);
         }
 
@@ -779,7 +786,7 @@ impl MessageRouterActorState {
         id: &PortalConversationId,
         response: Response,
         subscription_id: PortalSubscriptionId,
-    ) -> Result<Vec<SendOutcome>, ConversationError>
+    ) -> Result<Vec<EventSendResult>, ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -927,10 +934,12 @@ impl MessageRouterActorState {
         channel: &Arc<C>,
         event: Event,
         relays: Option<HashSet<String>>,
-    ) -> Result<SendOutcome, ConversationError>
+    ) -> Result<EventSendResult, ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
+        let event_id = event.id;
+
         let (failed, all_targeted) = if let Some(ref target_relays) = relays {
             let num_targets = target_relays.len();
             let failed_set = channel
@@ -950,7 +959,7 @@ impl MessageRouterActorState {
         };
 
         if failed.is_empty() {
-            return Ok(SendOutcome::Delivered);
+            return Ok(EventSendResult { event_id, outcome: SendOutcome::Delivered });
         }
 
         log::warn!(
@@ -968,16 +977,16 @@ impl MessageRouterActorState {
                 MAX_PENDING_RELAY_EVENTS,
                 event.id
             );
-            return Ok(SendOutcome::Dropped);
+            return Ok(EventSendResult { event_id, outcome: SendOutcome::Dropped });
         }
 
         self.pending_events.push((event, Some(failed.clone())));
 
         if failed.len() >= all_targeted {
-            Ok(SendOutcome::Queued)
+            Ok(EventSendResult { event_id, outcome: SendOutcome::Queued })
         } else {
             // At least one relay received the event
-            Ok(SendOutcome::Delivered)
+            Ok(EventSendResult { event_id, outcome: SendOutcome::Delivered })
         }
     }
 
@@ -1108,7 +1117,7 @@ impl MessageRouterActorState {
         &mut self,
         channel: &Arc<C>,
         conversation: ConversationBox,
-    ) -> Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>
+    ) -> Result<(PortalConversationId, Vec<EventSendResult>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -1127,7 +1136,7 @@ impl MessageRouterActorState {
         channel: &Arc<C>,
         conversation: ConversationBox,
         relays: Vec<String>,
-    ) -> Result<(PortalConversationId, Vec<SendOutcome>), ConversationError>
+    ) -> Result<(PortalConversationId, Vec<EventSendResult>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {
@@ -1191,7 +1200,7 @@ impl MessageRouterActorState {
         &mut self,
         channel: &Arc<C>,
         conversation: ConversationBox,
-    ) -> Result<(NotificationStream<T>, Vec<SendOutcome>), ConversationError>
+    ) -> Result<(NotificationStream<T>, Vec<EventSendResult>), ConversationError>
     where
         C::Error: From<nostr::types::url::Error>,
     {

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -27,8 +27,8 @@ const MAX_PENDING_RELAY_EVENTS: usize = 512;
 /// Outcome of attempting to send an event to relays.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SendOutcome {
-    /// At least one relay received the event.
-    Delivered,
+    /// At least one relay accepted the send; `relays` lists those URLs (from the pool send result).
+    Delivered { relays: Vec<String> },
     /// No relay was available; the event has been queued for retry.
     Queued,
     /// The pending queue was full and the event was dropped.
@@ -940,23 +940,25 @@ impl MessageRouterActorState {
     {
         let event_id = event.id;
 
-        let (failed, all_targeted) = if let Some(ref target_relays) = relays {
-            let num_targets = target_relays.len();
-            let failed_set = channel
+        let (failed, succeeded) = if let Some(ref target_relays) = relays {
+            channel
                 .broadcast_to(target_relays.clone(), event.clone())
                 .await
-                .map_err(|e| ConversationError::Inner(Box::new(e)))?;
-            (failed_set, num_targets)
+                .map_err(|e| ConversationError::Inner(Box::new(e)))?
         } else {
-            let (failed_set, total) = channel
+            channel
                 .broadcast(event.clone())
                 .await
-                .map_err(|e| ConversationError::Inner(Box::new(e)))?;
-            (failed_set, total)
+                .map_err(|e| ConversationError::Inner(Box::new(e)))?
         };
 
+        let all_targeted = failed.len() + succeeded.len();
+
         if failed.is_empty() {
-            return Ok(EventSendResult { event_id, outcome: SendOutcome::Delivered });
+            return Ok(EventSendResult {
+                event_id,
+                outcome: SendOutcome::Delivered { relays: succeeded },
+            });
         }
 
         log::warn!(
@@ -982,8 +984,10 @@ impl MessageRouterActorState {
         if failed.len() >= all_targeted {
             Ok(EventSendResult { event_id, outcome: SendOutcome::Queued })
         } else {
-            // At least one relay received the event
-            Ok(EventSendResult { event_id, outcome: SendOutcome::Delivered })
+            Ok(EventSendResult {
+                event_id,
+                outcome: SendOutcome::Delivered { relays: succeeded },
+            })
         }
     }
 
@@ -1037,18 +1041,14 @@ impl MessageRouterActorState {
                     .await
                     .map_err(|e| ConversationError::Inner(Box::new(e)))
             } else {
-                channel
-                    .broadcast(event.clone())
-                    .await
-                    .map(|(failed, _total)| failed)
-                    .map_err(|e| ConversationError::Inner(Box::new(e)))
+                channel.broadcast(event.clone()).await.map_err(|e| ConversationError::Inner(Box::new(e)))
             };
 
             match result {
-                Ok(f) if f.is_empty() => { /* success, event dropped */ }
-                Ok(f) => {
-                    log::warn!("Still failed on relay(s) {:?}, keeping queued", f);
-                    still_pending.push((event, Some(f)));
+                Ok((failed, _succeeded)) if failed.is_empty() => { /* success, event dropped */ }
+                Ok((failed, _)) => {
+                    log::warn!("Still failed on relay(s) {:?}, keeping queued", failed);
+                    still_pending.push((event, Some(failed)));
                 }
                 Err(e) => {
                     log::warn!("Flush error for event {:?}: {:?}, keeping queued", event.id, e);

--- a/crates/portal/src/router/actor.rs
+++ b/crates/portal/src/router/actor.rs
@@ -979,9 +979,10 @@ impl MessageRouterActorState {
             return Ok(EventSendResult { event_id, outcome: SendOutcome::Dropped });
         }
 
-        self.pending_events.push((event, Some(failed.clone())));
+        let all_failed = failed.len() >= all_targeted;
+        self.pending_events.push((event, Some(failed)));
 
-        if failed.len() >= all_targeted {
+        if all_failed {
             Ok(EventSendResult { event_id, outcome: SendOutcome::Queued })
         } else {
             Ok(EventSendResult {

--- a/crates/portal/src/router/channel.rs
+++ b/crates/portal/src/router/channel.rs
@@ -37,15 +37,16 @@ pub trait Channel: Send + 'static {
         id: PortalSubscriptionId,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 
+    /// Broadcast an event. Returns `(failed, succeeded)` relay URL strings.
     fn broadcast(
         &self,
         event: nostr::Event,
-    ) -> impl std::future::Future<Output = Result<(HashSet<String>, usize), Self::Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<(HashSet<String>, Vec<String>), Self::Error>> + Send;
     fn broadcast_to<I, U>(
         &self,
         urls: I,
         event: nostr::Event,
-    ) -> impl std::future::Future<Output = Result<HashSet<String>, Self::Error>> + Send
+    ) -> impl std::future::Future<Output = Result<(HashSet<String>, Vec<String>), Self::Error>> + Send
     where
         <I as IntoIterator>::IntoIter: Send,
         I: IntoIterator<Item = U> + Send,
@@ -115,13 +116,13 @@ impl Channel for RelayPool {
         Ok(())
     }
 
-    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, usize), Self::Error> {
+    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, Vec<String>), Self::Error> {
         let output = self.send_event(&event).await?;
-        let total = output.success.len() + output.failed.len();
         let failed: HashSet<String> = output.failed.keys().map(|u| u.to_string()).collect();
-        Ok((failed, total))
+        let succeeded: Vec<String> = output.success.iter().map(|u| u.to_string()).collect();
+        Ok((failed, succeeded))
     }
-    async fn broadcast_to<I, U>(&self, urls: I, event: nostr::Event) -> Result<HashSet<String>, Self::Error>
+    async fn broadcast_to<I, U>(&self, urls: I, event: nostr::Event) -> Result<(HashSet<String>, Vec<String>), Self::Error>
     where
         <I as IntoIterator>::IntoIter: Send,
         I: IntoIterator<Item = U> + Send,
@@ -130,7 +131,8 @@ impl Channel for RelayPool {
     {
         let output = self.send_event_to(urls, &event).await?;
         let failed: HashSet<String> = output.failed.keys().map(|u| u.to_string()).collect();
-        Ok(failed)
+        let succeeded: Vec<String> = output.success.iter().map(|u| u.to_string()).collect();
+        Ok((failed, succeeded))
     }
 
     async fn receive(&self) -> Result<RelayPoolNotification, Self::Error> {
@@ -172,11 +174,11 @@ impl<C: Channel + Send + Sync> Channel for std::sync::Arc<C> {
         <C as Channel>::unsubscribe(self, id).await
     }
 
-    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, usize), Self::Error> {
+    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, Vec<String>), Self::Error> {
         <C as Channel>::broadcast(self, event).await
     }
 
-    async fn broadcast_to<I, U>(&self, urls: I, event: nostr::Event) -> Result<HashSet<String>, Self::Error>
+    async fn broadcast_to<I, U>(&self, urls: I, event: nostr::Event) -> Result<(HashSet<String>, Vec<String>), Self::Error>
     where
         <I as IntoIterator>::IntoIter: Send,
         I: IntoIterator<Item = U> + Send,

--- a/crates/portal/src/router/channel.rs
+++ b/crates/portal/src/router/channel.rs
@@ -40,7 +40,7 @@ pub trait Channel: Send + 'static {
     fn broadcast(
         &self,
         event: nostr::Event,
-    ) -> impl std::future::Future<Output = Result<HashSet<String>, Self::Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<(HashSet<String>, usize), Self::Error>> + Send;
     fn broadcast_to<I, U>(
         &self,
         urls: I,
@@ -115,10 +115,11 @@ impl Channel for RelayPool {
         Ok(())
     }
 
-    async fn broadcast(&self, event: nostr::Event) -> Result<HashSet<String>, Self::Error> {
+    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, usize), Self::Error> {
         let output = self.send_event(&event).await?;
+        let total = output.success.len() + output.failed.len();
         let failed: HashSet<String> = output.failed.keys().map(|u| u.to_string()).collect();
-        Ok(failed)
+        Ok((failed, total))
     }
     async fn broadcast_to<I, U>(&self, urls: I, event: nostr::Event) -> Result<HashSet<String>, Self::Error>
     where
@@ -171,7 +172,7 @@ impl<C: Channel + Send + Sync> Channel for std::sync::Arc<C> {
         <C as Channel>::unsubscribe(self, id).await
     }
 
-    async fn broadcast(&self, event: nostr::Event) -> Result<HashSet<String>, Self::Error> {
+    async fn broadcast(&self, event: nostr::Event) -> Result<(HashSet<String>, usize), Self::Error> {
         <C as Channel>::broadcast(self, event).await
     }
 

--- a/crates/portal/src/router/mod.rs
+++ b/crates/portal/src/router/mod.rs
@@ -23,7 +23,7 @@ pub use adapters::multi_key_sender::{MultiKeySender, MultiKeySenderAdapter};
 pub use ids::{PortalConversationId, PortalSubscriptionId};
 
 // Re-export MessageRouterActor as MessageRouter for backward compatibility
-pub use actor::{MessageRouterActor as MessageRouter, MessageRouterActorError};
+pub use actor::{MessageRouterActor as MessageRouter, MessageRouterActorError, SendOutcome};
 
 #[derive(Debug)]
 struct ResponseEntry {

--- a/crates/portal/src/router/mod.rs
+++ b/crates/portal/src/router/mod.rs
@@ -23,7 +23,7 @@ pub use adapters::multi_key_sender::{MultiKeySender, MultiKeySenderAdapter};
 pub use ids::{PortalConversationId, PortalSubscriptionId};
 
 // Re-export MessageRouterActor as MessageRouter for backward compatibility
-pub use actor::{MessageRouterActor as MessageRouter, MessageRouterActorError, SendOutcome};
+pub use actor::{MessageRouterActor as MessageRouter, MessageRouterActorError, SendOutcome, EventSendResult};
 
 #[derive(Debug)]
 struct ResponseEntry {

--- a/crates/portal/src/test_framework/mod.rs
+++ b/crates/portal/src/test_framework/mod.rs
@@ -115,12 +115,13 @@ impl Channel for SimulatedChannel {
         Ok(())
     }
 
-    async fn broadcast(&self, event: Event) -> Result<HashSet<String>, Self::Error> {
+    async fn broadcast(&self, event: Event) -> Result<(HashSet<String>, usize), Self::Error> {
         // Store the event
         self.messages.lock().await.push(event.clone());
 
         // Broadcast to all subscribers
         let subscribers = self.subscribers.write().await;
+        let total = subscribers.len().max(1); // at least 1 simulated relay
         for (subscription_id, (filter, sender)) in subscribers.iter() {
             if filter.match_event(&event, MatchEventOptions::default()) {
                 let relay_url = RelayUrl::parse("wss://simulated").unwrap();
@@ -133,7 +134,7 @@ impl Channel for SimulatedChannel {
             }
         }
 
-        Ok(HashSet::new())
+        Ok((HashSet::new(), total))
     }
 
     async fn broadcast_to<I, U>(&self, urls: I, event: Event) -> Result<HashSet<String>, Self::Error>

--- a/crates/portal/src/test_framework/mod.rs
+++ b/crates/portal/src/test_framework/mod.rs
@@ -115,13 +115,13 @@ impl Channel for SimulatedChannel {
         Ok(())
     }
 
-    async fn broadcast(&self, event: Event) -> Result<(HashSet<String>, usize), Self::Error> {
+    async fn broadcast(&self, event: Event) -> Result<(HashSet<String>, Vec<String>), Self::Error> {
         // Store the event
         self.messages.lock().await.push(event.clone());
 
         // Broadcast to all subscribers
         let subscribers = self.subscribers.write().await;
-        let total = subscribers.len().max(1); // at least 1 simulated relay
+        let n = subscribers.len().max(1); // at least 1 simulated relay
         for (subscription_id, (filter, sender)) in subscribers.iter() {
             if filter.match_event(&event, MatchEventOptions::default()) {
                 let relay_url = RelayUrl::parse("wss://simulated").unwrap();
@@ -134,16 +134,22 @@ impl Channel for SimulatedChannel {
             }
         }
 
-        Ok((HashSet::new(), total))
+        let succeeded: Vec<String> = (0..n).map(|_| "wss://simulated".to_string()).collect();
+        Ok((HashSet::new(), succeeded))
     }
 
-    async fn broadcast_to<I, U>(&self, urls: I, event: Event) -> Result<HashSet<String>, Self::Error>
+    async fn broadcast_to<I, U>(&self, urls: I, event: Event) -> Result<(HashSet<String>, Vec<String>), Self::Error>
     where
         <I as IntoIterator>::IntoIter: Send,
         I: IntoIterator<Item = U> + Send,
         U: nostr::types::TryIntoUrl,
         Self::Error: From<<U as nostr::types::TryIntoUrl>::Err>,
     {
+        let url_strings: Vec<String> = urls
+            .into_iter()
+            .map(|u| Ok::<_, Self::Error>(u.try_into_url()?.to_string()))
+            .collect::<Result<Vec<_>, _>>()?;
+
         // Store the event
         self.messages.lock().await.push(event.clone());
 
@@ -161,7 +167,7 @@ impl Channel for SimulatedChannel {
             }
         }
 
-        Ok(HashSet::new())
+        Ok((HashSet::new(), url_strings))
     }
 
     async fn receive(&self) -> Result<RelayPoolNotification, Self::Error> {

--- a/crates/portal/src/test_framework/tests/auth_scenario.rs
+++ b/crates/portal/src/test_framework/tests/auth_scenario.rs
@@ -56,7 +56,7 @@ async fn test_auth_flow() {
     let client_router = network.get_node("client").unwrap();
 
     // 1. Service sets up to receive auth init
-    let mut service_notifications = service_router
+    let (mut service_notifications, _) = service_router
         .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
             KeyHandshakeReceiverConversation::new(service_keys.public_key(), token.clone()),
             None,
@@ -65,7 +65,7 @@ async fn test_auth_flow() {
         .unwrap();
 
     // 2. Client sets up to listen for auth challenge
-    let mut challenge_notifications = client_router
+    let (mut challenge_notifications, _) = client_router
         .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
             AuthChallengeListenerConversation::new(client_keys.public_key()),
             None,
@@ -94,7 +94,7 @@ async fn test_auth_flow() {
     assert_eq!(key_handshake_event.main_key, client_keys.public_key());
 
     // 5. Service sends auth challenge
-    let mut auth_response_event = service_router
+    let (mut auth_response_event, _) = service_router
         .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
             key_handshake_event.main_key,
             vec![],
@@ -187,7 +187,7 @@ async fn test_auth_with_subkey_client() {
     let client_router = network.get_node("client").unwrap();
 
     // 1. Client sets up to listen for auth challenge
-    let mut challenge_notifications = client_router
+    let (mut challenge_notifications, _) = client_router
         .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
             AuthChallengeListenerConversation::new(client_keys.public_key()),
             Some(client_subkey_proof.clone()),
@@ -196,7 +196,7 @@ async fn test_auth_with_subkey_client() {
         .unwrap();
 
     // 2. Service sends auth challenge (we explicitly don't set the subkey here so that the client has to negotiate it)
-    let mut auth_response_event = service_router
+    let (mut auth_response_event, _) = service_router
         .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
             client_keys_master.public_key(),
             vec![],
@@ -292,7 +292,7 @@ async fn test_auth_with_subkey_service() {
     let client_router = network.get_node("client").unwrap();
 
     // 1. Client sets up to listen for auth challenge
-    let mut challenge_notifications = client_router
+    let (mut challenge_notifications, _) = client_router
         .add_and_subscribe(Box::new(MultiKeyListenerAdapter::new(
             AuthChallengeListenerConversation::new(client_keys.public_key()),
             None,
@@ -301,7 +301,7 @@ async fn test_auth_with_subkey_service() {
         .unwrap();
 
     // 2. Service sends auth challenge (we explicitly don't set the subkey here so that the client has to negotiate it)
-    let mut auth_response_event = service_router
+    let (mut auth_response_event, _) = service_router
         .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
             client_keys.public_key(),
             vec![],


### PR DESCRIPTION
## Summary

Closes #85.

When no relay is connected, any command sent through the `MessageRouter` (handshake, payment, auth, cashu, ...) is silently queued in `pending_events` and the caller gets `Ok(())` with no indication the event wasn't actually delivered. This PR surfaces that information all the way up to external callers.

## Changes

### New types

```rust
pub enum SendOutcome {
    /// At least one relay accepted the event; includes relay URLs.
    Delivered { relays: Vec<String> },
    /// No relay was available; queued for retry.
    Queued,
    /// Pending queue full; event dropped.
    Dropped,
}

pub struct EventSendResult {
    pub event_id: nostr::EventId,
    pub outcome: SendOutcome,
}
```

Each broadcasted event produces an `EventSendResult` pairing the Nostr event ID with its delivery outcome. `Delivered` includes the list of relay URLs that accepted the event.

### Channel trait

`broadcast` and `broadcast_to` now return `(HashSet<String>, Vec<String>)` — (failed relay URLs, succeeded relay URLs). This gives `queue_event` the information it needs to accurately determine the outcome and attach successful relay URLs to `Delivered`.

### Core (`crates/portal/src/router/actor.rs`)

- `queue_event` returns `Result<EventSendResult, ConversationError>`
- `process_response` returns `Vec<EventSendResult>`
- `MessageRouterActorMessage` variants carry `Vec<EventSendResult>` in oneshot response types
- Public API (`add_conversation`, `add_conversation_with_relays`, `add_and_subscribe`) returns `(value, Vec<EventSendResult>)`
- `flush_pending_events` updated for the new `(failed, succeeded)` return type

### Exports

`SendOutcome` and `EventSendResult` re-exported from `crates/portal/src/router/mod.rs`.

### Callers

All callers in `portal-app`, `portal-sdk`, test framework, and test binaries destructure the new tuple with `_outcomes`. **Intentional** — mobile app behavior is preserved. The infrastructure is in place for consumers to react to outcomes when ready.

### SimulatedChannel

Test channel updated to return `(failed, succeeded)` with simulated relay URLs.

## Example usage

```rust
let (id, outcomes) = router.add_conversation(conv).await?;
for result in &outcomes {
    match &result.outcome {
        SendOutcome::Delivered { relays } => {
            log::info!("Event {} delivered to: {:?}", result.event_id, relays);
        }
        SendOutcome::Queued => {
            log::warn!("Event {} queued — no relay connected", result.event_id);
        }
        SendOutcome::Dropped => {
            log::error!("Event {} dropped — queue full", result.event_id);
        }
    }
}
```

## Verification

`cargo check --workspace` passes.