### PR TITLE
docs: bump version references to 0.4.1

### DIFF
--- a/docs/advanced/docker-deployment.md
+++ b/docs/advanced/docker-deployment.md
@@ -6,10 +6,10 @@
 docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=your-secret-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:0.3.0
+  getportal/sdk-daemon:0.4.1
 ```
 
-> **Tip:** pin a specific version in production (e.g. `0.3.0`) rather than `:latest` to avoid unexpected updates. The image is multi-arch (amd64 + arm64) — Docker pulls the right variant automatically. See [Versioning & Compatibility](../resources/versioning.md).
+> **Tip:** pin a specific version in production (e.g. `0.4.1`) rather than `:latest` to avoid unexpected updates. The image is multi-arch (amd64 + arm64) — Docker pulls the right variant automatically. See [Versioning & Compatibility](../resources/versioning.md).
 
 Check: curl http://localhost:3000/health, curl http://localhost:3000/version. WebSocket API: ws://localhost:3000/ws (auth required).
 
@@ -20,7 +20,7 @@ docker-compose.yml:
 ```yaml
 services:
   portal:
-    image: getportal/sdk-daemon:0.3.0
+    image: getportal/sdk-daemon:0.4.1
     ports: ["3000:3000"]
     environment:
       - PORTAL__AUTH__AUTH_TOKEN=${PORTAL__AUTH__AUTH_TOKEN}

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -195,7 +195,7 @@ docker run -d --name portal-sdk-daemon \
   -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=$PORTAL__AUTH__AUTH_TOKEN \
   -e PORTAL__NOSTR__PRIVATE_KEY=$PORTAL__NOSTR__PRIVATE_KEY \
-  getportal/sdk-daemon:0.3.0
+  getportal/sdk-daemon:0.4.1
 ```
 
 ### Health Check Failing
@@ -312,7 +312,7 @@ For Docker daemon:
 docker run -d \
   -e RUST_LOG=debug \
   ...
-  getportal/sdk-daemon:0.3.0
+  getportal/sdk-daemon:0.4.1
 
 # View debug logs
 docker logs -f portal-sdk-daemon

--- a/docs/resources/versioning.md
+++ b/docs/resources/versioning.md
@@ -18,7 +18,7 @@ All Portal components use **semantic versioning** (`major.minor.patch`):
 
 In other words:
 
-- SDK `0.3.0` ↔ SDK Daemon `0.3.0` ✅
+- SDK `0.4.1` ↔ SDK Daemon `0.4.1` ✅
 - SDK `0.3.4` ↔ SDK Daemon `0.3.1` ✅ (patch is irrelevant)
 - SDK `0.3.x` ↔ SDK Daemon `0.4.x` ❌ (minor mismatch)
 
@@ -53,6 +53,6 @@ implementation 'com.github.PortalTechnologiesInc:java-sdk:0.4.1'
 
 | Component | Version |
 |-----------|---------|
-| SDK Daemon (`getportal/sdk-daemon`) | `0.3.0` |
-| TypeScript SDK (`portal-sdk`) | `0.3.0` |
-| Java SDK | `0.3.0` |
+| SDK Daemon (`getportal/sdk-daemon`) | `0.4.1` |
+| TypeScript SDK (`portal-sdk`) | `0.4.1` |
+| Java SDK | `0.4.1` |


### PR DESCRIPTION
Updates docker-deployment, troubleshooting, and versioning docs from 0.3.0 to 0.4.1.