### PR TITLE
fix(router): avoid noisy unsubscribe errors on disconnected relays

### DIFF
--- a/crates/portal/src/router/channel.rs
+++ b/crates/portal/src/router/channel.rs
@@ -102,6 +102,14 @@ impl Channel for RelayPool {
             .relays_with_flag(RelayServiceFlags::READ, FlagCheck::All)
             .await;
         for relay in relays.values() {
+            if !relay.is_connected() {
+                log::debug!(
+                    "Skipping unsubscribe {id} for disconnected relay {}",
+                    relay.url()
+                );
+                continue;
+            }
+
             if let Err(e) = relay
                 .unsubscribe(&SubscriptionId::new(id.to_string()))
                 .await


### PR DESCRIPTION
## Summary
- skip unsubscribe/CLOSE for relays that are not connected
- log this case at `debug` level instead of emitting an error

## Why
When a relay is unreachable, it remains disconnected and never received the original subscription. Sending `unsubscribe` in cleanup is a no-op in that state and should not be treated as an error.

This removes false-positive error noise described in #177.

## Changes
- `crates/portal/src/router/channel.rs`
  - before calling `relay.unsubscribe(...)`, check `relay.is_connected()`
  - if disconnected, skip and emit a debug log

## Verification
- `nix develop -c cargo check -p portal`

Closes #177
