### PR TITLE
feat(portal): introduce typed amount primitives and currency-bound payment types

### DIFF
--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -19,9 +19,9 @@ use portal::protocol::calendar::Calendar;
 use portal::protocol::jwt::CustomClaims;
 use portal::protocol::model::payment::{
     CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, FiatCents, FiatCurrency,
-    InvoiceRequestContent, InvoiceRequestTyped, Millisats, MillisatsCurrency, PaymentStatus,
-    RecurringPaymentRequestContent, RecurringPaymentRequestTyped, SinglePaymentRequestContent,
-    SinglePaymentRequestTyped,
+    InvoiceRequestContent, InvoiceRequest, Millisats, MillisatsCurrency, PaymentStatus,
+    RecurringPaymentRequestContent, RecurringPaymentRequest, SinglePaymentRequestContent,
+    SinglePaymentRequest,
 };
 use portal::protocol::model::Timestamp;
 use portal::utils::fetch_nip05_profile as portal_fetch_nip05;
@@ -326,7 +326,7 @@ pub async fn request_recurring_payment(
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
     let payment_request: RecurringPaymentRequestContent = match req.payment_request.currency {
-        Currency::Millisats => RecurringPaymentRequestTyped {
+        Currency::Millisats => RecurringPaymentRequest {
             description: req.payment_request.description,
             amount: Millisats::new(req.payment_request.amount),
             currency: MillisatsCurrency,
@@ -337,7 +337,7 @@ pub async fn request_recurring_payment(
             current_exchange_rate,
         }
         .into(),
-        Currency::Fiat(code) => RecurringPaymentRequestTyped {
+        Currency::Fiat(code) => RecurringPaymentRequest {
             description: req.payment_request.description,
             amount: FiatCents::new(req.payment_request.amount),
             currency: FiatCurrency { code },
@@ -418,7 +418,7 @@ pub async fn request_single_payment(
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     let expires_at = Timestamp::now_plus_seconds(300);
     let payment_request: SinglePaymentRequestContent = match req.payment_request.currency {
-        Currency::Millisats => SinglePaymentRequestTyped {
+        Currency::Millisats => SinglePaymentRequest {
             amount: Millisats::new(amount),
             currency: MillisatsCurrency,
             expires_at,
@@ -430,7 +430,7 @@ pub async fn request_single_payment(
             description: Some(req.payment_request.description),
         }
         .into(),
-        Currency::Fiat(code) => SinglePaymentRequestTyped {
+        Currency::Fiat(code) => SinglePaymentRequest {
             amount: FiatCents::new(amount),
             currency: FiatCurrency { code },
             expires_at,
@@ -618,7 +618,7 @@ pub async fn request_invoice(
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
     let sdk_content: InvoiceRequestContent = match req.content.currency.clone() {
-        Currency::Millisats => InvoiceRequestTyped {
+        Currency::Millisats => InvoiceRequest {
             request_id,
             amount: Millisats::new(req.content.amount),
             currency: MillisatsCurrency,
@@ -628,7 +628,7 @@ pub async fn request_invoice(
             refund_invoice: req.content.refund_invoice.clone(),
         }
         .into(),
-        Currency::Fiat(code) => InvoiceRequestTyped {
+        Currency::Fiat(code) => InvoiceRequest {
             request_id,
             amount: FiatCents::new(req.content.amount),
             currency: FiatCurrency { code },

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -18,8 +18,10 @@ use portal::nostr_relay_pool::RelayOptions;
 use portal::protocol::calendar::Calendar;
 use portal::protocol::jwt::CustomClaims;
 use portal::protocol::model::payment::{
-    CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, InvoiceRequestContent,
-    PaymentStatus, RecurringPaymentRequestContent, SinglePaymentRequestContent,
+    CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, FiatCents, FiatCurrency,
+    InvoiceRequestContent, InvoiceRequestTyped, Millisats, MillisatsCurrency, PaymentStatus,
+    RecurringPaymentRequestContent, RecurringPaymentRequestTyped, SinglePaymentRequestContent,
+    SinglePaymentRequestTyped,
 };
 use portal::protocol::model::Timestamp;
 use portal::utils::fetch_nip05_profile as portal_fetch_nip05;
@@ -75,9 +77,9 @@ async fn resolve_amount_and_exchange_rate(
     amount: u64,
     currency: &Currency,
     market_api: Arc<portal_rates::MarketAPI>,
-) -> Result<(u64, Option<ExchangeRate>), portal_rates::RatesError> {
+) -> Result<(Millisats, Option<ExchangeRate>), portal_rates::RatesError> {
     match currency {
-        Currency::Millisats => Ok((amount, None)),
+        Currency::Millisats => Ok((Millisats::new(amount), None)),
         Currency::Fiat(currency_code) => {
             let market_data = market_api.fetch_market_data(currency_code).await?;
             let fiat_amount = amount as f64 / 100.0;
@@ -87,7 +89,7 @@ async fn resolve_amount_and_exchange_rate(
                 source: market_data.source,
                 time: Timestamp::now(),
             };
-            Ok((msat, Some(exchange_rate)))
+            Ok((Millisats::new(msat), Some(exchange_rate)))
         }
     }
 }
@@ -323,15 +325,29 @@ pub async fn request_recurring_payment(
     .await
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
-    let payment_request = RecurringPaymentRequestContent {
-        description: req.payment_request.description,
-        amount: req.payment_request.amount,
-        currency: req.payment_request.currency,
-        auth_token: req.payment_request.auth_token,
-        recurrence: req.payment_request.recurrence,
-        expires_at: req.payment_request.expires_at,
-        request_id: Uuid::new_v4().to_string(),
-        current_exchange_rate,
+    let payment_request: RecurringPaymentRequestContent = match req.payment_request.currency {
+        Currency::Millisats => RecurringPaymentRequestTyped {
+            description: req.payment_request.description,
+            amount: Millisats::new(req.payment_request.amount),
+            currency: MillisatsCurrency,
+            auth_token: req.payment_request.auth_token,
+            recurrence: req.payment_request.recurrence,
+            expires_at: req.payment_request.expires_at,
+            request_id: Uuid::new_v4().to_string(),
+            current_exchange_rate,
+        }
+        .into(),
+        Currency::Fiat(code) => RecurringPaymentRequestTyped {
+            description: req.payment_request.description,
+            amount: FiatCents::new(req.payment_request.amount),
+            currency: FiatCurrency { code },
+            auth_token: req.payment_request.auth_token,
+            recurrence: req.payment_request.recurrence,
+            expires_at: req.payment_request.expires_at,
+            request_id: Uuid::new_v4().to_string(),
+            current_exchange_rate,
+        }
+        .into(),
     };
 
     let stream_id = state.events.new_stream("recurring_payment", None).await;
@@ -341,7 +357,7 @@ pub async fn request_recurring_payment(
     let sid = stream_id.clone();
     tokio::spawn(async move {
         match sdk
-            .request_recurring_payment(main_key, subkeys, payment_request)
+            .request_recurring_payment_legacy(main_key, subkeys, payment_request)
             .await
         {
             Ok(status) => {
@@ -391,27 +407,46 @@ pub async fn request_single_payment(
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
     let invoice = wallet
-        .make_invoice(msat_amount, Some(req.payment_request.description.clone()))
+        .make_invoice_msat(msat_amount, Some(req.payment_request.description.clone()))
         .await
         .map_err(|e| internal_error(format!("Failed to make invoice: {e}")))?;
 
-    let request_id = req.payment_request.request_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
+    let request_id = req
+        .payment_request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
     let expires_at = Timestamp::now_plus_seconds(300);
-    let payment_request = SinglePaymentRequestContent {
-        amount,
-        currency: req.payment_request.currency,
-        expires_at,
-        invoice: invoice.clone(),
-        current_exchange_rate,
-        subscription_id: req.payment_request.subscription_id,
-        auth_token: req.payment_request.auth_token,
-        request_id,
-        description: Some(req.payment_request.description),
+    let payment_request: SinglePaymentRequestContent = match req.payment_request.currency {
+        Currency::Millisats => SinglePaymentRequestTyped {
+            amount: Millisats::new(amount),
+            currency: MillisatsCurrency,
+            expires_at,
+            invoice: invoice.clone(),
+            current_exchange_rate,
+            subscription_id: req.payment_request.subscription_id,
+            auth_token: req.payment_request.auth_token,
+            request_id,
+            description: Some(req.payment_request.description),
+        }
+        .into(),
+        Currency::Fiat(code) => SinglePaymentRequestTyped {
+            amount: FiatCents::new(amount),
+            currency: FiatCurrency { code },
+            expires_at,
+            invoice: invoice.clone(),
+            current_exchange_rate,
+            subscription_id: req.payment_request.subscription_id,
+            auth_token: req.payment_request.auth_token,
+            request_id,
+            description: Some(req.payment_request.description),
+        }
+        .into(),
     };
 
     let mut notifications = state
         .sdk
-        .request_single_payment(main_key, subkeys, payment_request)
+        .request_single_payment_legacy(main_key, subkeys, payment_request)
         .await
         .map_err(|e| internal_error(format!("Failed to request single payment: {e}")))?;
 
@@ -489,7 +524,7 @@ pub async fn request_payment_raw(
 
     let mut notifications = state
         .sdk
-        .request_single_payment(main_key, subkeys, req.payment_request)
+        .request_single_payment_legacy(main_key, subkeys, req.payment_request)
         .await
         .map_err(|e| internal_error(format!("Failed to request payment: {e}")))?;
 
@@ -582,14 +617,27 @@ pub async fn request_invoice(
     .await
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
-    let sdk_content = InvoiceRequestContent {
-        request_id,
-        amount: req.content.amount,
-        currency: req.content.currency.clone(),
-        current_exchange_rate,
-        expires_at: req.content.expires_at,
-        description: req.content.description.clone(),
-        refund_invoice: req.content.refund_invoice.clone(),
+    let sdk_content: InvoiceRequestContent = match req.content.currency.clone() {
+        Currency::Millisats => InvoiceRequestTyped {
+            request_id,
+            amount: Millisats::new(req.content.amount),
+            currency: MillisatsCurrency,
+            current_exchange_rate,
+            expires_at: req.content.expires_at,
+            description: req.content.description.clone(),
+            refund_invoice: req.content.refund_invoice.clone(),
+        }
+        .into(),
+        Currency::Fiat(code) => InvoiceRequestTyped {
+            request_id,
+            amount: FiatCents::new(req.content.amount),
+            currency: FiatCurrency { code },
+            current_exchange_rate,
+            expires_at: req.content.expires_at,
+            description: req.content.description.clone(),
+            refund_invoice: req.content.refund_invoice.clone(),
+        }
+        .into(),
     };
 
     let stream_id = state.events.new_stream("invoice_request", None).await;
@@ -599,7 +647,7 @@ pub async fn request_invoice(
     let sid = stream_id.clone();
     tokio::spawn(async move {
         match sdk
-            .request_invoice(recipient_key.into(), subkeys, sdk_content)
+            .request_invoice_legacy(recipient_key.into(), subkeys, sdk_content)
             .await
         {
             Ok(Some(resp)) => {
@@ -630,15 +678,16 @@ pub async fn request_invoice(
                     }
                 };
 
+                let expected_amount_msat_u64 = expected_amount_msat.as_u64();
                 let amount_diff =
-                    (invoice_amount_msat as i128 - expected_amount_msat as i128).abs();
+                    (invoice_amount_msat as i128 - expected_amount_msat_u64 as i128).abs();
                 if amount_diff > 1 {
                     events
                         .push(
                             &sid,
                             NotificationData::Error {
                                 reason: format!(
-                                    "Invoice amount mismatch: got {invoice_amount_msat} msat, expected {expected_amount_msat} msat (diff: {amount_diff} msat)"
+                                    "Invoice amount mismatch: got {invoice_amount_msat} msat, expected {expected_amount_msat_u64} msat (diff: {amount_diff} msat)"
                                 ),
                             },
                         )

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -19,8 +19,7 @@ use portal::protocol::calendar::Calendar;
 use portal::protocol::jwt::CustomClaims;
 use portal::protocol::model::payment::{
     CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, FiatCents, FiatCurrency,
-    InvoiceRequestContent, InvoiceRequest, Millisats, MillisatsCurrency, PaymentStatus,
-    RecurringPaymentRequestContent, RecurringPaymentRequest, SinglePaymentRequestContent,
+    InvoiceRequest, Millisats, MillisatsCurrency, PaymentStatus, RecurringPaymentRequest,
     SinglePaymentRequest,
 };
 use portal::protocol::model::Timestamp;
@@ -325,8 +324,13 @@ pub async fn request_recurring_payment(
     .await
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
-    let payment_request: RecurringPaymentRequestContent = match req.payment_request.currency {
-        Currency::Millisats => RecurringPaymentRequest {
+    enum AnyRecurringPaymentRequest {
+        Millisats(RecurringPaymentRequest<MillisatsCurrency>),
+        Fiat(RecurringPaymentRequest<FiatCurrency>),
+    }
+
+    let payment_request = match req.payment_request.currency {
+        Currency::Millisats => AnyRecurringPaymentRequest::Millisats(RecurringPaymentRequest {
             description: req.payment_request.description,
             amount: Millisats::new(req.payment_request.amount),
             currency: MillisatsCurrency,
@@ -335,9 +339,8 @@ pub async fn request_recurring_payment(
             expires_at: req.payment_request.expires_at,
             request_id: Uuid::new_v4().to_string(),
             current_exchange_rate,
-        }
-        .into(),
-        Currency::Fiat(code) => RecurringPaymentRequest {
+        }),
+        Currency::Fiat(code) => AnyRecurringPaymentRequest::Fiat(RecurringPaymentRequest {
             description: req.payment_request.description,
             amount: FiatCents::new(req.payment_request.amount),
             currency: FiatCurrency { code },
@@ -346,8 +349,7 @@ pub async fn request_recurring_payment(
             expires_at: req.payment_request.expires_at,
             request_id: Uuid::new_v4().to_string(),
             current_exchange_rate,
-        }
-        .into(),
+        }),
     };
 
     let stream_id = state.events.new_stream("recurring_payment", None).await;
@@ -356,10 +358,16 @@ pub async fn request_recurring_payment(
     let events = state.events.clone();
     let sid = stream_id.clone();
     tokio::spawn(async move {
-        match sdk
-            .request_recurring_payment_legacy(main_key, subkeys, payment_request)
-            .await
-        {
+        let result = match payment_request {
+            AnyRecurringPaymentRequest::Millisats(req) => {
+                sdk.request_recurring_payment(main_key, subkeys, req).await
+            }
+            AnyRecurringPaymentRequest::Fiat(req) => {
+                sdk.request_recurring_payment(main_key, subkeys, req).await
+            }
+        };
+
+        match result {
             Ok(status) => {
                 events
                     .push(
@@ -417,8 +425,13 @@ pub async fn request_single_payment(
         .clone()
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     let expires_at = Timestamp::now_plus_seconds(300);
-    let payment_request: SinglePaymentRequestContent = match req.payment_request.currency {
-        Currency::Millisats => SinglePaymentRequest {
+    enum AnySinglePaymentRequest {
+        Millisats(SinglePaymentRequest<MillisatsCurrency>),
+        Fiat(SinglePaymentRequest<FiatCurrency>),
+    }
+
+    let payment_request = match req.payment_request.currency {
+        Currency::Millisats => AnySinglePaymentRequest::Millisats(SinglePaymentRequest {
             amount: Millisats::new(amount),
             currency: MillisatsCurrency,
             expires_at,
@@ -428,9 +441,8 @@ pub async fn request_single_payment(
             auth_token: req.payment_request.auth_token,
             request_id,
             description: Some(req.payment_request.description),
-        }
-        .into(),
-        Currency::Fiat(code) => SinglePaymentRequest {
+        }),
+        Currency::Fiat(code) => AnySinglePaymentRequest::Fiat(SinglePaymentRequest {
             amount: FiatCents::new(amount),
             currency: FiatCurrency { code },
             expires_at,
@@ -440,15 +452,21 @@ pub async fn request_single_payment(
             auth_token: req.payment_request.auth_token,
             request_id,
             description: Some(req.payment_request.description),
-        }
-        .into(),
+        }),
     };
 
-    let mut notifications = state
-        .sdk
-        .request_single_payment_legacy(main_key, subkeys, payment_request)
-        .await
-        .map_err(|e| internal_error(format!("Failed to request single payment: {e}")))?;
+    let mut notifications = match payment_request {
+        AnySinglePaymentRequest::Millisats(req) => state
+            .sdk
+            .request_single_payment(main_key, subkeys.clone(), req)
+            .await
+            .map_err(|e| internal_error(format!("Failed to request single payment: {e}")))?,
+        AnySinglePaymentRequest::Fiat(req) => state
+            .sdk
+            .request_single_payment(main_key, subkeys, req)
+            .await
+            .map_err(|e| internal_error(format!("Failed to request single payment: {e}")))?,
+    };
 
     let metadata = StreamMetadata::SinglePayment {
         invoice: invoice.clone(),
@@ -522,11 +540,48 @@ pub async fn request_payment_raw(
     let main_key = hex_to_pubkey(&req.main_key).map_err(|e| bad_request(format!("Invalid main key: {e}")))?;
     let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
 
-    let mut notifications = state
-        .sdk
-        .request_single_payment_legacy(main_key, subkeys, req.payment_request)
-        .await
-        .map_err(|e| internal_error(format!("Failed to request payment: {e}")))?;
+    enum AnySinglePaymentRequest {
+        Millisats(SinglePaymentRequest<MillisatsCurrency>),
+        Fiat(SinglePaymentRequest<FiatCurrency>),
+    }
+
+    let payment_request = match req.payment_request.currency {
+        Currency::Millisats => AnySinglePaymentRequest::Millisats(SinglePaymentRequest {
+            amount: Millisats::new(req.payment_request.amount),
+            currency: MillisatsCurrency,
+            current_exchange_rate: req.payment_request.current_exchange_rate,
+            invoice: req.payment_request.invoice,
+            auth_token: req.payment_request.auth_token,
+            expires_at: req.payment_request.expires_at,
+            subscription_id: req.payment_request.subscription_id,
+            description: req.payment_request.description,
+            request_id: req.payment_request.request_id,
+        }),
+        Currency::Fiat(code) => AnySinglePaymentRequest::Fiat(SinglePaymentRequest {
+            amount: FiatCents::new(req.payment_request.amount),
+            currency: FiatCurrency { code },
+            current_exchange_rate: req.payment_request.current_exchange_rate,
+            invoice: req.payment_request.invoice,
+            auth_token: req.payment_request.auth_token,
+            expires_at: req.payment_request.expires_at,
+            subscription_id: req.payment_request.subscription_id,
+            description: req.payment_request.description,
+            request_id: req.payment_request.request_id,
+        }),
+    };
+
+    let mut notifications = match payment_request {
+        AnySinglePaymentRequest::Millisats(req) => state
+            .sdk
+            .request_single_payment(main_key, subkeys.clone(), req)
+            .await
+            .map_err(|e| internal_error(format!("Failed to request payment: {e}")))?,
+        AnySinglePaymentRequest::Fiat(req) => state
+            .sdk
+            .request_single_payment(main_key, subkeys, req)
+            .await
+            .map_err(|e| internal_error(format!("Failed to request payment: {e}")))?,
+    };
 
     let stream_id = state.events.new_stream("raw_payment", None).await;
 
@@ -617,8 +672,13 @@ pub async fn request_invoice(
     .await
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
-    let sdk_content: InvoiceRequestContent = match req.content.currency.clone() {
-        Currency::Millisats => InvoiceRequest {
+    enum AnyInvoiceRequest {
+        Millisats(InvoiceRequest<MillisatsCurrency>),
+        Fiat(InvoiceRequest<FiatCurrency>),
+    }
+
+    let sdk_content = match req.content.currency.clone() {
+        Currency::Millisats => AnyInvoiceRequest::Millisats(InvoiceRequest {
             request_id,
             amount: Millisats::new(req.content.amount),
             currency: MillisatsCurrency,
@@ -626,9 +686,8 @@ pub async fn request_invoice(
             expires_at: req.content.expires_at,
             description: req.content.description.clone(),
             refund_invoice: req.content.refund_invoice.clone(),
-        }
-        .into(),
-        Currency::Fiat(code) => InvoiceRequest {
+        }),
+        Currency::Fiat(code) => AnyInvoiceRequest::Fiat(InvoiceRequest {
             request_id,
             amount: FiatCents::new(req.content.amount),
             currency: FiatCurrency { code },
@@ -636,8 +695,7 @@ pub async fn request_invoice(
             expires_at: req.content.expires_at,
             description: req.content.description.clone(),
             refund_invoice: req.content.refund_invoice.clone(),
-        }
-        .into(),
+        }),
     };
 
     let stream_id = state.events.new_stream("invoice_request", None).await;
@@ -646,10 +704,16 @@ pub async fn request_invoice(
     let events = state.events.clone();
     let sid = stream_id.clone();
     tokio::spawn(async move {
-        match sdk
-            .request_invoice_legacy(recipient_key.into(), subkeys, sdk_content)
-            .await
-        {
+        let result = match sdk_content {
+            AnyInvoiceRequest::Millisats(req) => {
+                sdk.request_invoice(recipient_key.into(), subkeys, req).await
+            }
+            AnyInvoiceRequest::Fiat(req) => {
+                sdk.request_invoice(recipient_key.into(), subkeys, req).await
+            }
+        };
+
+        match result {
             Ok(Some(resp)) => {
                 // Validate amount
                 let invoice_amount_msat = match extract_invoice_amount_msat(&resp.invoice) {

--- a/crates/portal-sdk/src/lib.rs
+++ b/crates/portal-sdk/src/lib.rs
@@ -16,8 +16,10 @@ use portal::{
         model::payment::{
             CashuDirectContent, CashuRequestContent, CashuResponseContent,
             CloseRecurringPaymentContent, CloseRecurringPaymentResponse, InvoiceRequestContent,
-            InvoiceResponse, PaymentResponseContent, RecurringPaymentRequestContent,
+            InvoiceRequestTyped, InvoiceResponse, PaymentCurrencyKind, PaymentResponseContent,
+            RecurringPaymentRequestContent, RecurringPaymentRequestTyped,
             RecurringPaymentResponseContent, SinglePaymentRequestContent,
+            SinglePaymentRequestTyped,
         },
     },
     router::{
@@ -136,7 +138,29 @@ impl PortalSDK {
         Ok(event.next().await.ok_or(PortalSDKError::Timeout)??)
     }
 
-    pub async fn request_recurring_payment(
+    pub async fn request_recurring_payment<C: PaymentCurrencyKind>(
+        &self,
+        main_key: PublicKey,
+        subkeys: Vec<PublicKey>,
+        payment_request: RecurringPaymentRequestTyped<C>,
+    ) -> Result<RecurringPaymentResponseContent, PortalSDKError> {
+        let conv = RecurringPaymentRequestSenderConversation::new(
+            self.router.keypair().public_key(),
+            self.router.keypair().subkey_proof().cloned(),
+            payment_request.into(),
+        )
+        .map_err(PortalSDKError::ProtocolError)?;
+
+        let (mut event, _outcomes) = self
+            .router
+            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
+                main_key, subkeys, conv,
+            )))
+            .await?;
+        Ok(event.next().await.ok_or(PortalSDKError::Timeout)??)
+    }
+
+    pub async fn request_recurring_payment_legacy(
         &self,
         main_key: PublicKey,
         subkeys: Vec<PublicKey>,
@@ -158,7 +182,29 @@ impl PortalSDK {
         Ok(event.next().await.ok_or(PortalSDKError::Timeout)??)
     }
 
-    pub async fn request_single_payment(
+    pub async fn request_single_payment<C: PaymentCurrencyKind>(
+        &self,
+        main_key: PublicKey,
+        subkeys: Vec<PublicKey>,
+        payment_request: SinglePaymentRequestTyped<C>,
+    ) -> Result<NotificationStream<PaymentResponseContent>, PortalSDKError> {
+        let conv = SinglePaymentRequestSenderConversation::new(
+            self.router.keypair().public_key(),
+            self.router.keypair().subkey_proof().cloned(),
+            payment_request.into(),
+        )
+        .map_err(PortalSDKError::ProtocolError)?;
+
+        let (event, _outcomes) = self
+            .router
+            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
+                main_key, subkeys, conv,
+            )))
+            .await?;
+        Ok(event)
+    }
+
+    pub async fn request_single_payment_legacy(
         &self,
         main_key: PublicKey,
         subkeys: Vec<PublicKey>,
@@ -255,7 +301,32 @@ impl PortalSDK {
         Ok(())
     }
 
-    pub async fn request_invoice(
+    pub async fn request_invoice<C: PaymentCurrencyKind>(
+        &self,
+        recipient: PublicKey,
+        subkeys: Vec<PublicKey>,
+        content: InvoiceRequestTyped<C>,
+    ) -> Result<Option<InvoiceResponse>, PortalSDKError> {
+        let conv = InvoiceRequestConversation::new(
+            self.router.keypair().public_key(),
+            self.router.keypair().subkey_proof().cloned(),
+            content.into(),
+        );
+        let (mut rx, _outcomes) = self
+            .router
+            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
+                recipient, subkeys, conv,
+            )))
+            .await?;
+
+        if let Ok(invoice_response) = rx.next().await.ok_or(PortalSDKError::Timeout)? {
+            return Ok(Some(invoice_response));
+        }
+
+        Ok(None)
+    }
+
+    pub async fn request_invoice_legacy(
         &self,
         recipient: PublicKey,
         subkeys: Vec<PublicKey>,

--- a/crates/portal-sdk/src/lib.rs
+++ b/crates/portal-sdk/src/lib.rs
@@ -16,10 +16,10 @@ use portal::{
         model::payment::{
             CashuDirectContent, CashuRequestContent, CashuResponseContent,
             CloseRecurringPaymentContent, CloseRecurringPaymentResponse, InvoiceRequestContent,
-            InvoiceRequestTyped, InvoiceResponse, PaymentCurrencyKind, PaymentResponseContent,
-            RecurringPaymentRequestContent, RecurringPaymentRequestTyped,
+            InvoiceRequest, InvoiceResponse, PaymentCurrencyKind, PaymentResponseContent,
+            RecurringPaymentRequestContent, RecurringPaymentRequest,
             RecurringPaymentResponseContent, SinglePaymentRequestContent,
-            SinglePaymentRequestTyped,
+            SinglePaymentRequest,
         },
     },
     router::{
@@ -142,7 +142,7 @@ impl PortalSDK {
         &self,
         main_key: PublicKey,
         subkeys: Vec<PublicKey>,
-        payment_request: RecurringPaymentRequestTyped<C>,
+        payment_request: RecurringPaymentRequest<C>,
     ) -> Result<RecurringPaymentResponseContent, PortalSDKError> {
         let conv = RecurringPaymentRequestSenderConversation::new(
             self.router.keypair().public_key(),
@@ -186,7 +186,7 @@ impl PortalSDK {
         &self,
         main_key: PublicKey,
         subkeys: Vec<PublicKey>,
-        payment_request: SinglePaymentRequestTyped<C>,
+        payment_request: SinglePaymentRequest<C>,
     ) -> Result<NotificationStream<PaymentResponseContent>, PortalSDKError> {
         let conv = SinglePaymentRequestSenderConversation::new(
             self.router.keypair().public_key(),
@@ -305,7 +305,7 @@ impl PortalSDK {
         &self,
         recipient: PublicKey,
         subkeys: Vec<PublicKey>,
-        content: InvoiceRequestTyped<C>,
+        content: InvoiceRequest<C>,
     ) -> Result<Option<InvoiceResponse>, PortalSDKError> {
         let conv = InvoiceRequestConversation::new(
             self.router.keypair().public_key(),

--- a/crates/portal-sdk/src/lib.rs
+++ b/crates/portal-sdk/src/lib.rs
@@ -15,11 +15,9 @@ use portal::{
         key_handshake::KeyHandshakeUrl,
         model::payment::{
             CashuDirectContent, CashuRequestContent, CashuResponseContent,
-            CloseRecurringPaymentContent, CloseRecurringPaymentResponse, InvoiceRequestContent,
-            InvoiceRequest, InvoiceResponse, PaymentCurrencyKind, PaymentResponseContent,
-            RecurringPaymentRequestContent, RecurringPaymentRequest,
-            RecurringPaymentResponseContent, SinglePaymentRequestContent,
-            SinglePaymentRequest,
+            CloseRecurringPaymentContent, CloseRecurringPaymentResponse, InvoiceRequest,
+            InvoiceResponse, PaymentCurrencyKind, PaymentResponseContent,
+            RecurringPaymentRequest, RecurringPaymentResponseContent, SinglePaymentRequest,
         },
     },
     router::{
@@ -160,28 +158,6 @@ impl PortalSDK {
         Ok(event.next().await.ok_or(PortalSDKError::Timeout)??)
     }
 
-    pub async fn request_recurring_payment_legacy(
-        &self,
-        main_key: PublicKey,
-        subkeys: Vec<PublicKey>,
-        payment_request: RecurringPaymentRequestContent,
-    ) -> Result<RecurringPaymentResponseContent, PortalSDKError> {
-        let conv = RecurringPaymentRequestSenderConversation::new(
-            self.router.keypair().public_key(),
-            self.router.keypair().subkey_proof().cloned(),
-            payment_request,
-        )
-        .map_err(PortalSDKError::ProtocolError)?;
-
-        let (mut event, _outcomes) = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
-                main_key, subkeys, conv,
-            )))
-            .await?;
-        Ok(event.next().await.ok_or(PortalSDKError::Timeout)??)
-    }
-
     pub async fn request_single_payment<C: PaymentCurrencyKind>(
         &self,
         main_key: PublicKey,
@@ -192,28 +168,6 @@ impl PortalSDK {
             self.router.keypair().public_key(),
             self.router.keypair().subkey_proof().cloned(),
             payment_request.into(),
-        )
-        .map_err(PortalSDKError::ProtocolError)?;
-
-        let (event, _outcomes) = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
-                main_key, subkeys, conv,
-            )))
-            .await?;
-        Ok(event)
-    }
-
-    pub async fn request_single_payment_legacy(
-        &self,
-        main_key: PublicKey,
-        subkeys: Vec<PublicKey>,
-        payment_request: SinglePaymentRequestContent,
-    ) -> Result<NotificationStream<PaymentResponseContent>, PortalSDKError> {
-        let conv = SinglePaymentRequestSenderConversation::new(
-            self.router.keypair().public_key(),
-            self.router.keypair().subkey_proof().cloned(),
-            payment_request,
         )
         .map_err(PortalSDKError::ProtocolError)?;
 
@@ -311,31 +265,6 @@ impl PortalSDK {
             self.router.keypair().public_key(),
             self.router.keypair().subkey_proof().cloned(),
             content.into(),
-        );
-        let (mut rx, _outcomes) = self
-            .router
-            .add_and_subscribe(Box::new(MultiKeySenderAdapter::new_with_user(
-                recipient, subkeys, conv,
-            )))
-            .await?;
-
-        if let Ok(invoice_response) = rx.next().await.ok_or(PortalSDKError::Timeout)? {
-            return Ok(Some(invoice_response));
-        }
-
-        Ok(None)
-    }
-
-    pub async fn request_invoice_legacy(
-        &self,
-        recipient: PublicKey,
-        subkeys: Vec<PublicKey>,
-        content: InvoiceRequestContent,
-    ) -> Result<Option<InvoiceResponse>, PortalSDKError> {
-        let conv = InvoiceRequestConversation::new(
-            self.router.keypair().public_key(),
-            self.router.keypair().subkey_proof().cloned(),
-            content,
         );
         let (mut rx, _outcomes) = self
             .router

--- a/crates/portal-wallet/src/lib.rs
+++ b/crates/portal-wallet/src/lib.rs
@@ -2,6 +2,7 @@ mod breez;
 mod nwc;
 
 use axum::async_trait;
+use portal::protocol::model::payment::Millisats;
 
 pub use breez::BreezSparkWallet;
 pub use nwc::NwcWallet;
@@ -16,6 +17,27 @@ pub trait PortalWallet: Send + Sync {
     async fn get_balance(&self) -> Result<u64>;
     /// Pay invoice, returns (preimage, fees_paid_msat)
     async fn pay_invoice(&self, invoice: String) -> Result<(String, u64)>;
+
+    /// Typed helper (non-breaking): same as `make_invoice` but explicit unit.
+    async fn make_invoice_msat(
+        &self,
+        amount: Millisats,
+        description: Option<String>,
+    ) -> Result<String> {
+        self.make_invoice(amount.as_u64(), description).await
+    }
+
+    /// Typed helper (non-breaking): balance in explicit msat unit.
+    async fn get_balance_msat(&self) -> Result<Millisats> {
+        self.get_balance().await.map(Millisats::new)
+    }
+
+    /// Typed helper (non-breaking): returns typed fees in explicit msat unit.
+    async fn pay_invoice_msat(&self, invoice: String) -> Result<(String, Millisats)> {
+        self.pay_invoice(invoice)
+            .await
+            .map(|(preimage, fees_msat)| (preimage, Millisats::new(fees_msat)))
+    }
 }
 
 /// Result type for Portal Wallet operations

--- a/crates/portal/src/protocol/model.rs
+++ b/crates/portal/src/protocol/model.rs
@@ -383,7 +383,7 @@ pub mod payment {
     }
 
     #[derive(Debug, Clone)]
-    pub struct SinglePaymentRequestTyped<C: PaymentCurrencyKind> {
+    pub struct SinglePaymentRequest<C: PaymentCurrencyKind> {
         pub amount: C::Amount,
         pub currency: C,
         pub current_exchange_rate: Option<ExchangeRate>,
@@ -395,8 +395,8 @@ pub mod payment {
         pub request_id: String,
     }
 
-    impl<C: PaymentCurrencyKind> From<SinglePaymentRequestTyped<C>> for SinglePaymentRequestContent {
-        fn from(value: SinglePaymentRequestTyped<C>) -> Self {
+    impl<C: PaymentCurrencyKind> From<SinglePaymentRequest<C>> for SinglePaymentRequestContent {
+        fn from(value: SinglePaymentRequest<C>) -> Self {
             Self {
                 amount: value.amount.into(),
                 currency: value.currency.into_currency(),
@@ -412,7 +412,7 @@ pub mod payment {
     }
 
     #[derive(Debug, Clone)]
-    pub struct RecurringPaymentRequestTyped<C: PaymentCurrencyKind> {
+    pub struct RecurringPaymentRequest<C: PaymentCurrencyKind> {
         pub amount: C::Amount,
         pub currency: C,
         pub recurrence: RecurrenceInfo,
@@ -423,8 +423,8 @@ pub mod payment {
         pub request_id: String,
     }
 
-    impl<C: PaymentCurrencyKind> From<RecurringPaymentRequestTyped<C>> for RecurringPaymentRequestContent {
-        fn from(value: RecurringPaymentRequestTyped<C>) -> Self {
+    impl<C: PaymentCurrencyKind> From<RecurringPaymentRequest<C>> for RecurringPaymentRequestContent {
+        fn from(value: RecurringPaymentRequest<C>) -> Self {
             Self {
                 amount: value.amount.into(),
                 currency: value.currency.into_currency(),
@@ -439,7 +439,7 @@ pub mod payment {
     }
 
     #[derive(Debug, Clone)]
-    pub struct InvoiceRequestTyped<C: PaymentCurrencyKind> {
+    pub struct InvoiceRequest<C: PaymentCurrencyKind> {
         pub request_id: String,
         pub amount: C::Amount,
         pub currency: C,
@@ -449,8 +449,8 @@ pub mod payment {
         pub refund_invoice: Option<String>,
     }
 
-    impl<C: PaymentCurrencyKind> From<InvoiceRequestTyped<C>> for InvoiceRequestContent {
-        fn from(value: InvoiceRequestTyped<C>) -> Self {
+    impl<C: PaymentCurrencyKind> From<InvoiceRequest<C>> for InvoiceRequestContent {
+        fn from(value: InvoiceRequest<C>) -> Self {
             Self {
                 request_id: value.request_id,
                 amount: value.amount.into(),

--- a/crates/portal/src/protocol/model.rs
+++ b/crates/portal/src/protocol/model.rs
@@ -286,12 +286,181 @@ pub mod payment {
         }
     }
 
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[serde(transparent)]
+    #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+    pub struct Millisats {
+        pub value: u64,
+    }
+
+    impl Millisats {
+        pub const fn new(value: u64) -> Self {
+            Self { value }
+        }
+
+        pub const fn as_u64(self) -> u64 {
+            self.value
+        }
+    }
+
+    impl From<u64> for Millisats {
+        fn from(value: u64) -> Self {
+            Self::new(value)
+        }
+    }
+
+    impl From<Millisats> for u64 {
+        fn from(value: Millisats) -> Self {
+            value.value
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[serde(transparent)]
+    #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+    pub struct FiatCents {
+        pub value: u64,
+    }
+
+    impl FiatCents {
+        pub const fn new(value: u64) -> Self {
+            Self { value }
+        }
+
+        pub const fn as_u64(self) -> u64 {
+            self.value
+        }
+    }
+
+    impl From<u64> for FiatCents {
+        fn from(value: u64) -> Self {
+            Self::new(value)
+        }
+    }
+
+    impl From<FiatCents> for u64 {
+        fn from(value: FiatCents) -> Self {
+            value.value
+        }
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
     #[cfg_attr(feature = "bindings", derive(uniffi::Enum))]
     pub enum Currency {
         Millisats,
         #[serde(untagged)]
         Fiat(String),
+    }
+
+    /// Type-system mapping between currency and amount unit.
+    pub trait PaymentCurrencyKind {
+        type Amount: Into<u64> + Copy;
+        fn into_currency(self) -> Currency;
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct MillisatsCurrency;
+
+    impl PaymentCurrencyKind for MillisatsCurrency {
+        type Amount = Millisats;
+
+        fn into_currency(self) -> Currency {
+            Currency::Millisats
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct FiatCurrency {
+        pub code: String,
+    }
+
+    impl PaymentCurrencyKind for FiatCurrency {
+        type Amount = FiatCents;
+
+        fn into_currency(self) -> Currency {
+            Currency::Fiat(self.code)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct SinglePaymentRequestTyped<C: PaymentCurrencyKind> {
+        pub amount: C::Amount,
+        pub currency: C,
+        pub current_exchange_rate: Option<ExchangeRate>,
+        pub invoice: String,
+        pub auth_token: Option<String>,
+        pub expires_at: Timestamp,
+        pub subscription_id: Option<String>,
+        pub description: Option<String>,
+        pub request_id: String,
+    }
+
+    impl<C: PaymentCurrencyKind> From<SinglePaymentRequestTyped<C>> for SinglePaymentRequestContent {
+        fn from(value: SinglePaymentRequestTyped<C>) -> Self {
+            Self {
+                amount: value.amount.into(),
+                currency: value.currency.into_currency(),
+                current_exchange_rate: value.current_exchange_rate,
+                invoice: value.invoice,
+                auth_token: value.auth_token,
+                expires_at: value.expires_at,
+                subscription_id: value.subscription_id,
+                description: value.description,
+                request_id: value.request_id,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RecurringPaymentRequestTyped<C: PaymentCurrencyKind> {
+        pub amount: C::Amount,
+        pub currency: C,
+        pub recurrence: RecurrenceInfo,
+        pub current_exchange_rate: Option<ExchangeRate>,
+        pub expires_at: Timestamp,
+        pub auth_token: Option<String>,
+        pub description: Option<String>,
+        pub request_id: String,
+    }
+
+    impl<C: PaymentCurrencyKind> From<RecurringPaymentRequestTyped<C>> for RecurringPaymentRequestContent {
+        fn from(value: RecurringPaymentRequestTyped<C>) -> Self {
+            Self {
+                amount: value.amount.into(),
+                currency: value.currency.into_currency(),
+                recurrence: value.recurrence,
+                current_exchange_rate: value.current_exchange_rate,
+                expires_at: value.expires_at,
+                auth_token: value.auth_token,
+                description: value.description,
+                request_id: value.request_id,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct InvoiceRequestTyped<C: PaymentCurrencyKind> {
+        pub request_id: String,
+        pub amount: C::Amount,
+        pub currency: C,
+        pub current_exchange_rate: Option<ExchangeRate>,
+        pub expires_at: Timestamp,
+        pub description: Option<String>,
+        pub refund_invoice: Option<String>,
+    }
+
+    impl<C: PaymentCurrencyKind> From<InvoiceRequestTyped<C>> for InvoiceRequestContent {
+        fn from(value: InvoiceRequestTyped<C>) -> Self {
+            Self {
+                request_id: value.request_id,
+                amount: value.amount.into(),
+                currency: value.currency.into_currency(),
+                current_exchange_rate: value.current_exchange_rate,
+                expires_at: value.expires_at,
+                description: value.description,
+                refund_invoice: value.refund_invoice,
+            }
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -305,6 +474,38 @@ pub mod payment {
         pub auth_token: Option<String>,
         pub description: Option<String>,
         pub request_id: String,
+    }
+
+    impl SinglePaymentRequestContent {
+        pub fn amount_millisats(&self) -> Option<Millisats> {
+            match self.currency {
+                Currency::Millisats => Some(Millisats::new(self.amount)),
+                Currency::Fiat(_) => None,
+            }
+        }
+
+        pub fn amount_fiat_cents(&self) -> Option<FiatCents> {
+            match self.currency {
+                Currency::Fiat(_) => Some(FiatCents::new(self.amount)),
+                Currency::Millisats => None,
+            }
+        }
+    }
+
+    impl RecurringPaymentRequestContent {
+        pub fn amount_millisats(&self) -> Option<Millisats> {
+            match self.currency {
+                Currency::Millisats => Some(Millisats::new(self.amount)),
+                Currency::Fiat(_) => None,
+            }
+        }
+
+        pub fn amount_fiat_cents(&self) -> Option<FiatCents> {
+            match self.currency {
+                Currency::Fiat(_) => Some(FiatCents::new(self.amount)),
+                Currency::Millisats => None,
+            }
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -353,6 +554,30 @@ pub mod payment {
         */
     }
 
+    impl RecurringPaymentStatus {
+        pub fn authorized_amount_millisats(&self) -> Option<Millisats> {
+            match self {
+                Self::Confirmed {
+                    authorized_amount,
+                    authorized_currency: Currency::Millisats,
+                    ..
+                } => Some(Millisats::new(*authorized_amount)),
+                _ => None,
+            }
+        }
+
+        pub fn authorized_amount_fiat_cents(&self) -> Option<FiatCents> {
+            match self {
+                Self::Confirmed {
+                    authorized_amount,
+                    authorized_currency: Currency::Fiat(_),
+                    ..
+                } => Some(FiatCents::new(*authorized_amount)),
+                _ => None,
+            }
+        }
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
     pub struct CloseRecurringPaymentContent {
@@ -379,6 +604,22 @@ pub mod payment {
         pub expires_at: Timestamp,
         pub description: Option<String>,
         pub refund_invoice: Option<String>,
+    }
+
+    impl InvoiceRequestContent {
+        pub fn amount_millisats(&self) -> Option<Millisats> {
+            match self.currency {
+                Currency::Millisats => Some(Millisats::new(self.amount)),
+                Currency::Fiat(_) => None,
+            }
+        }
+
+        pub fn amount_fiat_cents(&self) -> Option<FiatCents> {
+            match self.currency {
+                Currency::Fiat(_) => Some(FiatCents::new(self.amount)),
+                Currency::Millisats => None,
+            }
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
This PR moves payment amounts toward **type-system enforcement** while keeping external/mobile compatibility intact.

### Core typed primitives
- Added `Millisats` (`u64` wrapper)
- Added `FiatCents` (`u64` wrapper)

### Currency-bound typed payment models
In `portal::protocol::model::payment`:
- `PaymentCurrencyKind` trait with associated `Amount`
- `MillisatsCurrency` (`Amount = Millisats`)
- `FiatCurrency { code }` (`Amount = FiatCents`)
- Typed request models:
  - `SinglePaymentRequestTyped<C>`
  - `RecurringPaymentRequestTyped<C>`
  - `InvoiceRequestTyped<C>`
- Conversion from typed models into wire/content structs remains available.

### SDK/API direction (typed-first)
In `portal-sdk`:
- Primary request methods now use typed models:
  - `request_single_payment<C>(SinglePaymentRequestTyped<C>)`
  - `request_recurring_payment<C>(RecurringPaymentRequestTyped<C>)`
  - `request_invoice<C>(InvoiceRequestTyped<C>)`
- Legacy methods kept as compatibility shims:
  - `request_single_payment_legacy(...)`
  - `request_recurring_payment_legacy(...)`
  - `request_invoice_legacy(...)`

### Wallet/rest typed integration
- `portal-wallet` adds typed msat helper methods
- `portal-rest` uses typed msat wrappers in amount resolution and invoice checks

## Compatibility
- No wire-format break for mobile bindings / REST payloads (`amount: u64` + `currency` still supported)
- Rust internal code can now be migrated to compile-time currency/amount pairing

## Verification
- `nix develop -c cargo check -p portal -p portal-wallet -p portal-rest -p portal-sdk`

Refs #151
