### PR TITLE
feat(amount): add lightweight Amount wrapper for msats/fiat cents

### DIFF
--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -18,8 +18,9 @@ use portal::nostr_relay_pool::RelayOptions;
 use portal::protocol::calendar::Calendar;
 use portal::protocol::jwt::CustomClaims;
 use portal::protocol::model::payment::{
-    CashuDirectContent, CashuRequestContent, Currency, ExchangeRate, InvoiceRequestContent,
-    PaymentStatus, RecurringPaymentRequestContent, SinglePaymentRequestContent,
+    Amount, CashuDirectContent, CashuRequestContent, Currency, ExchangeRate,
+    InvoiceRequestContent, PaymentStatus, RecurringPaymentRequestContent,
+    SinglePaymentRequestContent,
 };
 use portal::protocol::model::Timestamp;
 use portal::utils::fetch_nip05_profile as portal_fetch_nip05;
@@ -72,22 +73,22 @@ fn parse_subkeys(subkeys: &[String]) -> Result<Vec<PublicKey>, String> {
 /// Resolve amount and exchange rate: for Millisats returns (amount, None);
 /// for Fiat fetches market data and returns (amount_msat, Some(ExchangeRate)).
 async fn resolve_amount_and_exchange_rate(
-    amount: u64,
+    amount: Amount,
     currency: &Currency,
     market_api: Arc<portal_rates::MarketAPI>,
-) -> Result<(u64, Option<ExchangeRate>), portal_rates::RatesError> {
+) -> Result<(Amount, Option<ExchangeRate>), portal_rates::RatesError> {
     match currency {
         Currency::Millisats => Ok((amount, None)),
         Currency::Fiat(currency_code) => {
             let market_data = market_api.fetch_market_data(currency_code).await?;
-            let fiat_amount = amount as f64 / 100.0;
+            let fiat_amount = amount.as_fiat_major();
             let msat = (market_data.calculate_millisats(fiat_amount) as i64).max(0) as u64;
             let exchange_rate = ExchangeRate {
                 rate: market_data.rate,
                 source: market_data.source,
                 time: Timestamp::now(),
             };
-            Ok((msat, Some(exchange_rate)))
+            Ok((Amount::new(msat), Some(exchange_rate)))
         }
     }
 }
@@ -316,7 +317,7 @@ pub async fn request_recurring_payment(
     let subkeys = parse_subkeys(&req.subkeys).map_err(|e| bad_request(format!("Invalid subkeys: {e}")))?;
 
     let (_, current_exchange_rate) = resolve_amount_and_exchange_rate(
-        req.payment_request.amount,
+        Amount::new(req.payment_request.amount),
         &req.payment_request.currency,
         state.market_api.clone(),
     )
@@ -383,7 +384,7 @@ pub async fn request_single_payment(
 
     let amount = req.payment_request.amount;
     let (msat_amount, current_exchange_rate) = resolve_amount_and_exchange_rate(
-        amount,
+        Amount::new(amount),
         &req.payment_request.currency,
         state.market_api.clone(),
     )
@@ -391,7 +392,7 @@ pub async fn request_single_payment(
     .map_err(|e| internal_error(format!("Failed to fetch market data: {e}")))?;
 
     let invoice = wallet
-        .make_invoice(msat_amount, Some(req.payment_request.description.clone()))
+        .make_invoice(msat_amount.as_millisats(), Some(req.payment_request.description.clone()))
         .await
         .map_err(|e| internal_error(format!("Failed to make invoice: {e}")))?;
 
@@ -575,7 +576,7 @@ pub async fn request_invoice(
 
     // Resolve amount/exchange rate synchronously — errors returned as 400
     let (expected_amount_msat, current_exchange_rate) = resolve_amount_and_exchange_rate(
-        req.content.amount,
+        Amount::new(req.content.amount),
         &req.content.currency,
         state.market_api.clone(),
     )
@@ -630,15 +631,15 @@ pub async fn request_invoice(
                     }
                 };
 
-                let amount_diff =
-                    (invoice_amount_msat as i128 - expected_amount_msat as i128).abs();
+                let expected_msat = expected_amount_msat.as_millisats();
+                let amount_diff = (invoice_amount_msat as i128 - expected_msat as i128).abs();
                 if amount_diff > 1 {
                     events
                         .push(
                             &sid,
                             NotificationData::Error {
                                 reason: format!(
-                                    "Invoice amount mismatch: got {invoice_amount_msat} msat, expected {expected_amount_msat} msat (diff: {amount_diff} msat)"
+                                    "Invoice amount mismatch: got {invoice_amount_msat} msat, expected {expected_msat} msat (diff: {amount_diff} msat)"
                                 ),
                             },
                         )

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -727,7 +727,7 @@ pub async fn request_cashu(
     let content = CashuRequestContent {
         mint_url: req.mint_url,
         unit: req.unit,
-        amount: Amount::new(req.amount),
+        amount: req.amount,
         request_id: Uuid::new_v4().to_string(),
         expires_at,
     };
@@ -1057,7 +1057,7 @@ async fn spawn_verification_token_request(
     let content = CashuRequestContent {
         mint_url: VERIFICATION_MINT_URL.to_string(),
         unit: VERIFICATION_TICKET_UNIT.to_string(),
-        amount: Amount::new(VERIFICATION_TOKEN_AMOUNT),
+        amount: VERIFICATION_TOKEN_AMOUNT,
         request_id: Uuid::new_v4().to_string(),
         expires_at,
     };

--- a/crates/portal-rest/src/handlers.rs
+++ b/crates/portal-rest/src/handlers.rs
@@ -326,7 +326,7 @@ pub async fn request_recurring_payment(
 
     let payment_request = RecurringPaymentRequestContent {
         description: req.payment_request.description,
-        amount: req.payment_request.amount,
+        amount: Amount::new(req.payment_request.amount),
         currency: req.payment_request.currency,
         auth_token: req.payment_request.auth_token,
         recurrence: req.payment_request.recurrence,
@@ -399,7 +399,7 @@ pub async fn request_single_payment(
     let request_id = req.payment_request.request_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
     let expires_at = Timestamp::now_plus_seconds(300);
     let payment_request = SinglePaymentRequestContent {
-        amount,
+        amount: Amount::new(amount),
         currency: req.payment_request.currency,
         expires_at,
         invoice: invoice.clone(),
@@ -585,7 +585,7 @@ pub async fn request_invoice(
 
     let sdk_content = InvoiceRequestContent {
         request_id,
-        amount: req.content.amount,
+        amount: Amount::new(req.content.amount),
         currency: req.content.currency.clone(),
         current_exchange_rate,
         expires_at: req.content.expires_at,
@@ -727,7 +727,7 @@ pub async fn request_cashu(
     let content = CashuRequestContent {
         mint_url: req.mint_url,
         unit: req.unit,
-        amount: req.amount,
+        amount: Amount::new(req.amount),
         request_id: Uuid::new_v4().to_string(),
         expires_at,
     };
@@ -1057,7 +1057,7 @@ async fn spawn_verification_token_request(
     let content = CashuRequestContent {
         mint_url: VERIFICATION_MINT_URL.to_string(),
         unit: VERIFICATION_TICKET_UNIT.to_string(),
-        amount: VERIFICATION_TOKEN_AMOUNT,
+        amount: Amount::new(VERIFICATION_TOKEN_AMOUNT),
         request_id: Uuid::new_v4().to_string(),
         expires_at,
     };

--- a/crates/portal/src/conversation/app/payments.rs
+++ b/crates/portal/src/conversation/app/payments.rs
@@ -133,8 +133,8 @@ impl PaymentRequestContent {
 
     pub fn amount(&self) -> u64 {
         match self {
-            Self::Single(content) => content.amount,
-            Self::Recurring(content) => content.amount,
+            Self::Single(content) => content.amount.as_u64(),
+            Self::Recurring(content) => content.amount.as_u64(),
         }
     }
 }

--- a/crates/portal/src/conversation/sdk/payments.rs
+++ b/crates/portal/src/conversation/sdk/payments.rs
@@ -32,7 +32,7 @@ impl RecurringPaymentRequestSenderConversation {
         subkey_proof: Option<SubkeyProof>,
         payment_request: RecurringPaymentRequestContent,
     ) -> Result<Self, String> {
-        if payment_request.amount == 0 {
+        if payment_request.amount.as_u64() == 0 {
             return Err("Recurring payment amount must be greater than zero".to_string());
         }
 
@@ -125,7 +125,7 @@ impl SinglePaymentRequestSenderConversation {
         subkey_proof: Option<SubkeyProof>,
         payment_request: SinglePaymentRequestContent,
     ) -> Result<Self, String> {
-        if payment_request.amount == 0 {
+        if payment_request.amount.as_u64() == 0 {
             return Err("Payment amount must be greater than zero".to_string());
         }
 

--- a/crates/portal/src/protocol/model.rs
+++ b/crates/portal/src/protocol/model.rs
@@ -245,6 +245,47 @@ pub mod payment {
 
     use super::*;
 
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[serde(transparent)]
+    #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+    pub struct Amount {
+        pub value: u64,
+    }
+
+    impl Amount {
+        pub const fn new(value: u64) -> Self {
+            Self { value }
+        }
+
+        pub const fn as_u64(self) -> u64 {
+            self.value
+        }
+
+        pub const fn as_millisats(self) -> u64 {
+            self.value
+        }
+
+        pub const fn as_fiat_cents(self) -> u64 {
+            self.value
+        }
+
+        pub fn as_fiat_major(self) -> f64 {
+            self.value as f64 / 100.0
+        }
+    }
+
+    impl From<u64> for Amount {
+        fn from(value: u64) -> Self {
+            Self::new(value)
+        }
+    }
+
+    impl From<Amount> for u64 {
+        fn from(value: Amount) -> Self {
+            value.value
+        }
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
     pub struct SinglePaymentRequestContent {

--- a/crates/portal/src/protocol/model.rs
+++ b/crates/portal/src/protocol/model.rs
@@ -444,7 +444,7 @@ pub mod payment {
         pub request_id: String,
         pub mint_url: String,
         pub unit: String,
-        pub amount: Amount,
+        pub amount: u64,
         pub expires_at: Timestamp,
     }
 

--- a/crates/portal/src/protocol/model.rs
+++ b/crates/portal/src/protocol/model.rs
@@ -289,7 +289,7 @@ pub mod payment {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
     pub struct SinglePaymentRequestContent {
-        pub amount: u64,
+        pub amount: Amount,
         pub currency: Currency,
         pub current_exchange_rate: Option<ExchangeRate>,
         pub invoice: String,
@@ -338,7 +338,7 @@ pub mod payment {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
     pub struct RecurringPaymentRequestContent {
-        pub amount: u64,
+        pub amount: Amount,
         pub currency: Currency,
         pub recurrence: RecurrenceInfo,
         pub current_exchange_rate: Option<ExchangeRate>,
@@ -379,7 +379,7 @@ pub mod payment {
     pub enum RecurringPaymentStatus {
         Confirmed {
             subscription_id: String,
-            authorized_amount: u64,
+            authorized_amount: Amount,
             authorized_currency: Currency,
             authorized_recurrence: RecurrenceInfo,
         },
@@ -414,7 +414,7 @@ pub mod payment {
     #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
     pub struct InvoiceRequestContent {
         pub request_id: String,
-        pub amount: u64,
+        pub amount: Amount,
         pub currency: Currency,
         pub current_exchange_rate: Option<ExchangeRate>,
         pub expires_at: Timestamp,
@@ -444,7 +444,7 @@ pub mod payment {
         pub request_id: String,
         pub mint_url: String,
         pub unit: String,
-        pub amount: u64,
+        pub amount: Amount,
         pub expires_at: Timestamp,
     }
 


### PR DESCRIPTION
## Summary
- close out the large typed-currency refactor in favor of a minimal approach
- introduce `Amount(u64)` wrapper in `portal::protocol::model::payment`
- add helper methods:
  - `as_millisats()`
  - `as_fiat_cents()`
  - `as_fiat_major()` (`/100.0`)
- use `Amount` in `portal-rest` amount resolution path while keeping wire JSON unchanged

## Compatibility
- no schema/wire break: `amount` in JSON remains `u64`
- mobile/bindings remain compatible

## Verification
- `nix develop -c cargo check -p portal -p portal-rest -p portal-wallet -p portal-sdk`

Refs #151
